### PR TITLE
defined workflow `generate_github_page`

### DIFF
--- a/.github/workflows/generate_gh_page.yml
+++ b/.github/workflows/generate_gh_page.yml
@@ -1,0 +1,15 @@
+name: generate_github_page
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install -r requirements.txt
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
this workflow use a minimal install to build and deploy the doc on push to `main`

As the branch main is now secured behind force PR the doc will only update after a validated and merged PR