### PR TITLE
Added group `azure adt`

### DIFF
--- a/Babylon/groups/azure/groups/__init__.py
+++ b/Babylon/groups/azure/groups/__init__.py
@@ -1,5 +1,7 @@
+from .adt import adt
 from .adx import adx
 
 list_groups = [
+    adt,
     adx,
 ]

--- a/Babylon/groups/azure/groups/adt/__init__.py
+++ b/Babylon/groups/azure/groups/adt/__init__.py
@@ -1,0 +1,25 @@
+from azure.digitaltwins.core import DigitalTwinsClient
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+from .....utils.decorators import require_deployment_key
+
+@group()
+@pass_context
+@require_deployment_key("digital_twin_url", "digital_twin_url")
+def adt(ctx: Context, digital_twin_url: str):
+    """Allow communication with Azure Digital Twin"""
+
+    ctx.obj = DigitalTwinsClient(credential=ctx.parent.obj,
+                                 endpoint=digital_twin_url)
+
+
+for _command in list_commands:
+    adt.add_command(_command)
+
+for _group in list_groups:
+    adt.add_command(_group)

--- a/Babylon/groups/azure/groups/adt/commands/__init__.py
+++ b/Babylon/groups/azure/groups/adt/commands/__init__.py
@@ -1,5 +1,7 @@
+from .list_models import list_models
 from .upload_model import upload_model
 
 list_commands = [
+    list_models,
     upload_model,
 ]

--- a/Babylon/groups/azure/groups/adt/commands/__init__.py
+++ b/Babylon/groups/azure/groups/adt/commands/__init__.py
@@ -1,0 +1,5 @@
+from .upload_model import upload_model
+
+list_commands = [
+    upload_model,
+]

--- a/Babylon/groups/azure/groups/adt/commands/list_models.py
+++ b/Babylon/groups/azure/groups/adt/commands/list_models.py
@@ -28,22 +28,19 @@ def list_models(dt_client: DigitalTwinsClient, output_file: Optional[pathlib.Pat
     """Upload MODEL_FILE to adt
 
     MODEL_FILE must be a json file"""
-    if output_file:
-        if output_file.suffix != ".json":
-            logger.error(f"{output_file} is not a json file")
-            return
+    if output_file and output_file.suffix != ".json":
+        logger.error(f"{output_file} is not a json file")
+        return
 
     data = dt_client.list_models(include_model_definition=True)
 
-    if not output_file:
-        logger.info("Listing all model ids :")
+    logger.info("Listing all model ids :")
+        
     _file_content = []
-
     for model in data:
         model: DigitalTwinsModelData
-        if output_file is None:
-            logger.info(f"  - {model.as_dict()['model']['@id']}")
-        else:
+        logger.info(f"  - {model.as_dict()['model']['@id']}")
+        if output_file:
             _file_content.append(model.as_dict())
 
     if output_file:

--- a/Babylon/groups/azure/groups/adt/commands/upload_model.py
+++ b/Babylon/groups/azure/groups/adt/commands/upload_model.py
@@ -1,0 +1,70 @@
+import json
+import logging
+import pathlib
+import pprint
+
+import click
+from azure.core.exceptions import ResourceExistsError
+from azure.core.exceptions import ResourceNotFoundError
+from azure.digitaltwins.core import DigitalTwinsClient
+from click import argument
+from click import command
+from click import make_pass_decorator
+from click import option
+
+logger = logging.getLogger("Babylon")
+
+pass_dt_client = make_pass_decorator(DigitalTwinsClient)
+
+
+def upload_one_model(dt_client: DigitalTwinsClient, model: dict, override: bool) -> bool:
+    """
+    Send only one model to the ADT
+    :param dt_client: DigitalTwinsClient instance used to send the model
+    :param model: dict object containing the model
+    :param override: Should the model be overridden if it exists ?
+    :return: True if the model was uploaded
+    """
+    try:
+        model_id = model['@id']
+    except KeyError:
+        logger.error("Given model is missing `@id`")
+        return False
+
+    if override:
+        try:
+            m = dt_client.get_model(model_id)
+            logger.info(f"Deleting model `{model_id}`")
+            dt_client.delete_model(model_id)
+        except ResourceNotFoundError:
+            pass
+
+    logger.info(f"Uploading model `{model_id}`")
+    logger.debug(pprint.pformat(model))
+
+    try:
+        dt_client.create_models([model, ])
+    except ResourceExistsError:
+        logger.error(f"Model `{model_id}` already exists")
+        return False
+    return True
+
+
+@command()
+@pass_dt_client
+@argument("model_file", type=click.Path(exists=True,
+                                        file_okay=True,
+                                        dir_okay=False,
+                                        readable=True,
+                                        path_type=pathlib.Path))
+@option("-o", "--override", "override_if_exists", is_flag=True, help="Override existing models")
+def upload_model(dt_client: DigitalTwinsClient, model_file: pathlib.Path, override_if_exists: bool):
+    """Upload MODEL_FILE to adt"""
+
+    model_file_content = json.load(open(model_file, 'r'))
+
+    if type(model_file_content) is list:
+        for model in model_file_content:
+            upload_one_model(dt_client, model, override_if_exists)
+    else:
+        upload_one_model(dt_client, model_file_content, override_if_exists)

--- a/Babylon/groups/azure/groups/adt/commands/upload_model.py
+++ b/Babylon/groups/azure/groups/adt/commands/upload_model.py
@@ -11,18 +11,20 @@ from click import argument
 from click import command
 from click import make_pass_decorator
 from click import option
+from ......utils.decorators import allow_dry_run
 
 logger = logging.getLogger("Babylon")
 
 pass_dt_client = make_pass_decorator(DigitalTwinsClient)
 
 
-def upload_one_model(dt_client: DigitalTwinsClient, model: dict, override: bool) -> bool:
+def upload_one_model(dt_client: DigitalTwinsClient, model: dict, override: bool, dry_run: bool) -> bool:
     """
     Send only one model to the ADT
     :param dt_client: DigitalTwinsClient instance used to send the model
     :param model: dict object containing the model
     :param override: Should the model be overridden if it exists ?
+    :param dry_run: are we in dry run mode ?
     :return: True if the model was uploaded
     """
     try:
@@ -32,21 +34,23 @@ def upload_one_model(dt_client: DigitalTwinsClient, model: dict, override: bool)
         return False
 
     if override:
-        try:
-            m = dt_client.get_model(model_id)
-            logger.info(f"Deleting model `{model_id}`")
-            dt_client.delete_model(model_id)
-        except ResourceNotFoundError:
-            pass
+        logger.info(f"Deleting model `{model_id}`")
+        if not dry_run:
+            try:
+                _ = dt_client.get_model(model_id)
+                dt_client.delete_model(model_id)
+            except ResourceNotFoundError:
+                pass
 
     logger.info(f"Uploading model `{model_id}`")
     logger.debug(pprint.pformat(model))
 
-    try:
-        dt_client.create_models([model, ])
-    except ResourceExistsError:
-        logger.error(f"Model `{model_id}` already exists")
-        return False
+    if not dry_run:
+        try:
+            dt_client.create_models([model, ])
+        except ResourceExistsError:
+            logger.error(f"Model `{model_id}` already exists")
+            return False
     return True
 
 
@@ -58,13 +62,20 @@ def upload_one_model(dt_client: DigitalTwinsClient, model: dict, override: bool)
                                         readable=True,
                                         path_type=pathlib.Path))
 @option("-o", "--override", "override_if_exists", is_flag=True, help="Override existing models")
-def upload_model(dt_client: DigitalTwinsClient, model_file: pathlib.Path, override_if_exists: bool):
-    """Upload MODEL_FILE to adt"""
+@allow_dry_run
+def upload_model(dt_client: DigitalTwinsClient, model_file: pathlib.Path, override_if_exists: bool, dry_run: bool):
+    """Upload MODEL_FILE to adt
+
+    MODEL_FILE must be a json file"""
+
+    if model_file.suffix != ".json":
+        logger.error(f"{model_file} is not a json file")
+        return
 
     model_file_content = json.load(open(model_file, 'r'))
 
     if type(model_file_content) is list:
         for model in model_file_content:
-            upload_one_model(dt_client, model, override_if_exists)
+            upload_one_model(dt_client, model, override_if_exists, dry_run)
     else:
-        upload_one_model(dt_client, model_file_content, override_if_exists)
+        upload_one_model(dt_client, model_file_content, override_if_exists, dry_run)

--- a/Babylon/groups/azure/groups/adt/groups/__init__.py
+++ b/Babylon/groups/azure/groups/adt/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/templates/config_template/deployments/deploy.yaml
+++ b/Babylon/templates/config_template/deployments/deploy.yaml
@@ -8,3 +8,5 @@ workspace_id: ""
 api_url: ""
 # database_name : the name of the database used in Azure Data Explorer
 database_name: ""
+# digital_twin_url : URL of the digital twin to use
+digital_twin_url: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@ azure-mgmt-subscription
 azure-mgmt-kusto
 msrest
 
+# Azure services requirements
+azure-digitaltwins-core
+
 # Click requirements
 click
 click-log


### PR DESCRIPTION
This group contains 2 commands :
- `azure adt upload-model` : take a json file containing one or more models and send them to ADT (with `--override` allows update of models existing in ADT, else will return an error when trying to send a model with an id already existing)
- `azure adt list-models` : list the ids of existing models in the ADT (with `--output_file` allows to output the full content of the query to a json file