### PR TITLE
Jfoll/automate config api connectors prod 10164

### DIFF
--- a/Babylon/groups/api/groups/__init__.py
+++ b/Babylon/groups/api/groups/__init__.py
@@ -1,7 +1,9 @@
+from .connector import connector
 from .organization import organization
 from .solution import solution
 
 list_groups = [
+    connector,
     organization,
     solution,
 ]

--- a/Babylon/groups/api/groups/connector/__init__.py
+++ b/Babylon/groups/api/groups/connector/__init__.py
@@ -1,0 +1,24 @@
+import cosmotech_api
+from click import group, pass_context
+from click.core import Context
+from cosmotech_api.api.connector_api import ConnectorApi
+
+from .....utils.decorators import pass_api_configuration
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_api_configuration
+@pass_context
+def connector(ctx: Context, api_configuration):
+    """Subgroup handling Connectors in the cosmotech API"""
+    api_client = cosmotech_api.ApiClient(api_configuration)
+    ctx.obj = ConnectorApi(api_client)
+
+
+for _command in list_commands:
+    connector.add_command(_command)
+
+for _group in list_groups:
+    connector.add_command(_group)

--- a/Babylon/groups/api/groups/connector/commands/__init__.py
+++ b/Babylon/groups/api/groups/connector/commands/__init__.py
@@ -1,0 +1,11 @@
+from .delete import delete
+from .get_all import get_all
+from .get import get
+from .create import create
+
+list_commands = [
+    delete,
+    get_all,
+    get,
+    create,
+]

--- a/Babylon/groups/api/groups/connector/commands/create.py
+++ b/Babylon/groups/api/groups/connector/commands/create.py
@@ -1,12 +1,15 @@
 from logging import getLogger
 from pprint import pformat
+from typing import Optional
 
-from click import argument, command, make_pass_decorator, option
+from click import argument, command, make_pass_decorator, option, Choice
 from cosmotech_api.api.connector_api import ConnectorApi
 from cosmotech_api.exceptions import UnauthorizedException
 
 from ......utils.api import get_api_file
-from ......utils.decorators import allow_dry_run, timing_decorator
+from ......utils import TEMPLATE_FOLDER_PATH
+from ......utils.decorators import allow_dry_run, pass_environment, timing_decorator
+from ......utils.environment import Environment
 
 logger = getLogger("Babylon")
 
@@ -17,7 +20,8 @@ pass_connector_api = make_pass_decorator(ConnectorApi)
 @allow_dry_run
 @timing_decorator
 @pass_connector_api
-@argument("connector_file", type=str)
+@pass_environment
+@argument("connector_file", type=str, required=False)
 @option(
     "-e",
     "--use-working-dir-file",
@@ -25,34 +29,78 @@ pass_connector_api = make_pass_decorator(ConnectorApi)
     is_flag=True,
     help="Should the path be relative to the working directory ?",
 )
+@option(
+    "-t",
+    "--type",
+    "connector_type",
+    required=True,
+    type=Choice(["ADT", "STORAGE"], case_sensitive=True),
+    help="Connector type, allowed values : [ADT, STORAGE]",
+)
+@option(
+    "-n",
+    "--name",
+    "connector_name",
+    required=True,
+    type=str,
+    help="New connector name",
+)
+@option(
+    "-v",
+    "--version",
+    "connector_version",
+    required=True,
+    type=str,
+    help="New connector version",
+)
 def create(
+    env: Environment,
     connector_api: ConnectorApi,
-    connector_file: str,
+    connector_type: str,
+    connector_name: str,
+    connector_version: str,
+    connector_file: Optional[str] = None,
     use_working_dir_file: bool = False,
     dry_run: bool = False,
 ):
     """Register new connector by sending a JSON or YAML file to the API."""
 
-    if (
-        converted_connector_content := get_api_file(
-            api_file_path=connector_file,
-            use_working_dir_file=use_working_dir_file,
-            logger=logger,
-        )
-    ) is not None:
+    converted_connector_content = get_api_file(
+        api_file_path=connector_file
+        if connector_file
+        else f"{TEMPLATE_FOLDER_PATH}/working_dir_template/API/Connector.{connector_type}.yaml",
+        use_working_dir_file=use_working_dir_file if connector_file else False,
+        logger=logger,
+    )
+
+    if (converted_connector_content) is not None:
         try:
 
             if not dry_run:
                 retrieved_connector = connector_api.register_connector(
                     connector=converted_connector_content
                 )
+                converted_connector_content["name"] = connector_name
+                converted_connector_content["key"] = "".join(connector_name.split(" "))
+                converted_connector_content["version"] = connector_version
+
+                if connector_type == "ADT":
+                    env.configuration.set_deploy_var(
+                        "adt_connector_id", retrieved_connector["id"]
+                    )
+                elif connector_type == "STORAGE":
+                    env.configuration.set_deploy_var(
+                        "azure_storage_connector_id", retrieved_connector["id"]
+                    )
             else:
                 logger.info("DRY RUN - Would call connector_api.create_connector")
                 retrieved_connector = converted_connector_content
                 retrieved_connector["id"] = "<DRY RUN>"
 
             logger.debug(pformat(retrieved_connector))
-            logger.info(f"Created new connector with id: {retrieved_connector['id']}")
+            logger.info(
+                f"Created new {connector_type} Connector with id: {retrieved_connector['id']}"
+            )
 
         except UnauthorizedException:
             logger.error("Unauthorized access to the cosmotech api")

--- a/Babylon/groups/api/groups/connector/commands/create.py
+++ b/Babylon/groups/api/groups/connector/commands/create.py
@@ -1,0 +1,63 @@
+from logging import getLogger
+from pprint import pformat
+
+from click import argument, command, make_pass_decorator, option
+from cosmotech_api.api.connector_api import ConnectorApi
+from cosmotech_api.exceptions import UnauthorizedException
+
+from ......utils.api import get_api_file
+from ......utils.decorators import allow_dry_run, timing_decorator
+
+logger = getLogger("Babylon")
+
+pass_connector_api = make_pass_decorator(ConnectorApi)
+
+
+@command()
+@allow_dry_run
+@timing_decorator
+@pass_connector_api
+@argument("connector_file", type=str)
+@option(
+    "-e",
+    "--use-working-dir-file",
+    "use_working_dir_file",
+    is_flag=True,
+    help="Should the path be relative to the working directory ?",
+)
+def create(
+    connector_api: ConnectorApi,
+    connector_file: str,
+    use_working_dir_file: bool = False,
+    dry_run: bool = False,
+):
+    """Register new connector by sending a JSON or YAML file to the API."""
+
+    if (
+        converted_connector_content := get_api_file(
+            api_file_path=connector_file,
+            use_working_dir_file=use_working_dir_file,
+            logger=logger,
+        )
+    ) is not None:
+        try:
+
+            if not dry_run:
+                retrieved_connector = connector_api.register_connector(
+                    connector=converted_connector_content
+                )
+            else:
+                logger.info("DRY RUN - Would call connector_api.create_connector")
+                retrieved_connector = converted_connector_content
+                retrieved_connector["id"] = "<DRY RUN>"
+
+            logger.debug(pformat(retrieved_connector))
+            logger.info(f"Created new connector with id: {retrieved_connector['id']}")
+
+        except UnauthorizedException:
+            logger.error("Unauthorized access to the cosmotech api")
+
+    else:
+        logger.error(
+            "Error : can not get correct Connector definition, please check your Connector.YAML file"
+        )

--- a/Babylon/groups/api/groups/connector/commands/create.py
+++ b/Babylon/groups/api/groups/connector/commands/create.py
@@ -77,12 +77,13 @@ def create(
         try:
 
             if not dry_run:
-                retrieved_connector = connector_api.register_connector(
-                    connector=converted_connector_content
-                )
                 converted_connector_content["name"] = connector_name
                 converted_connector_content["key"] = "".join(connector_name.split(" "))
                 converted_connector_content["version"] = connector_version
+
+                retrieved_connector = connector_api.register_connector(
+                    connector=converted_connector_content
+                )
 
                 if connector_type == "ADT":
                     env.configuration.set_deploy_var(

--- a/Babylon/groups/api/groups/connector/commands/delete.py
+++ b/Babylon/groups/api/groups/connector/commands/delete.py
@@ -21,13 +21,15 @@ def delete(
     connector_id: str,
     dry_run: bool = False,
 ):
-    """Unregister a connector via Cosmotech APi."""
+    """Unregister a connector via Cosmotech API."""
+    try:
+        if not dry_run:
+            _ = connector_api.find_connector_by_id(connector_id)  #
+        if confirm(
+            f"You are trying to delete connector {connector_id} \nDo you want to continue ?"
+        ):
+            confirm_connector_id = prompt("Confirm connector id ")
 
-    if confirm(
-        f"You are trying to delete connector {connector_id} \nDo you want to continue ?"
-    ):
-        confirm_connector_id = connector_id
-        try:
             if confirm_connector_id == connector_id:
                 if dry_run:
 
@@ -39,11 +41,12 @@ def delete(
                     logger.info(f"Connector with id {connector_id} deleted.")
             else:
                 logger.error(
-                    "The connector id you have type don't mach with connector with id {connector_id} name"
+                    "Wrong Connector , the id must be the same as the one that has been provide in delete command  argument"
                 )
-        except UnauthorizedException:
-            logger.error("Unauthorized access to the cosmotech api")
-        except NotFoundException:
-            logger.error(f"Connector with id {connector_id} does not exists.")
-    else:
-        logger.info("Connector deletion aborted.")
+
+        else:
+            logger.info("Connector deletion aborted.")
+    except UnauthorizedException:
+        logger.error("Unauthorized access to the cosmotech api.")
+    except NotFoundException:
+        logger.error(f"Connector with id {connector_id} does not exists.")

--- a/Babylon/groups/api/groups/connector/commands/delete.py
+++ b/Babylon/groups/api/groups/connector/commands/delete.py
@@ -1,0 +1,49 @@
+from logging import getLogger
+
+from click import argument, command, confirm, make_pass_decorator, prompt
+from cosmotech_api.api.connector_api import ConnectorApi
+from cosmotech_api.exceptions import NotFoundException, UnauthorizedException
+
+from ......utils.decorators import allow_dry_run, timing_decorator
+
+logger = getLogger("Babylon")
+
+pass_connector_api = make_pass_decorator(ConnectorApi)
+
+
+@command()
+@allow_dry_run
+@timing_decorator
+@pass_connector_api
+@argument("connector_id", type=str)
+def delete(
+    connector_api: ConnectorApi,
+    connector_id: str,
+    dry_run: bool = False,
+):
+    """Unregister a connector via Cosmotech APi."""
+
+    if confirm(
+        f"You are trying to delete connector {connector_id} \nDo you want to continue ?"
+    ):
+        confirm_connector_id = connector_id
+        try:
+            if confirm_connector_id == connector_id:
+                if dry_run:
+
+                    logger.info(
+                        "DRY RUN - Would call connector_api.unregister_connector"
+                    )
+                else:
+                    _ = connector_api.unregister_connector(connector_id)
+                    logger.info(f"Connector with id {connector_id} deleted.")
+            else:
+                logger.error(
+                    "The connector id you have type don't mach with connector with id {connector_id} name"
+                )
+        except UnauthorizedException:
+            logger.error("Unauthorized access to the cosmotech api")
+        except NotFoundException:
+            logger.error(f"Connector with id {connector_id} does not exists.")
+    else:
+        logger.info("Connector deletion aborted.")

--- a/Babylon/groups/api/groups/connector/commands/get.py
+++ b/Babylon/groups/api/groups/connector/commands/get.py
@@ -1,0 +1,75 @@
+import json
+from logging import getLogger
+from pprint import pformat
+from typing import Optional
+
+from cosmotech_api.exceptions import NotFoundException, UnauthorizedException
+from click import argument, command, make_pass_decorator, option
+from cosmotech_api.api.connector_api import ConnectorApi
+
+from ......utils.api import (
+    convert_keys_case,
+    filter_api_response_item,
+    underscore_to_camel,
+)
+from ......utils.decorators import (
+    allow_dry_run,
+    timing_decorator,
+)
+
+logger = getLogger("Babylon")
+
+pass_connector_api = make_pass_decorator(ConnectorApi)
+
+
+@command()
+@allow_dry_run
+@timing_decorator
+@pass_connector_api
+@option(
+    "-o",
+    "--output_file",
+    "output_file",
+    help="File to which content should be outputted (json-formatted)",
+    type=str,
+)
+@argument("connector_id", type=str)
+@option(
+    "-f",
+    "--fields",
+    "fields",
+    required=False,
+    type=str,
+    help="Fields witch will be keep in response data, by default all",
+)
+def get(
+    connector_api: ConnectorApi,
+    connector_id,
+    output_file: Optional[str] = None,
+    fields: str = None,
+    dry_run: bool = False,
+):
+    """Get an registered connector data."""
+    try:
+        if dry_run:
+            logger.info("DRY RUN - Would call connector_api.find_connector_by_id")
+            retrieved_connector = {"Babylon": "<DRY RUN>"}
+        else:
+            retrieved_connector = connector_api.find_connector_by_id(connector_id)
+            if fields is not None:
+                retrieved_connector = filter_api_response_item(
+                    retrieved_connector, fields.split(",")
+                )
+        if output_file is not None:
+            converted_content = convert_keys_case(
+                retrieved_connector.to_dict(), underscore_to_camel
+            )
+            with open(output_file, "w") as _file:
+                json.dump(converted_content, _file, ensure_ascii=False)
+            logger.info(f"Connector {connector_id} data was dumped on {output_file}")
+        else:
+            logger.info(pformat(retrieved_connector))
+    except UnauthorizedException :
+        logger.error("Unauthorized access to the cosmotech api")
+    except NotFoundException :
+        logger.error(f"Connector with id {connector_id} does not exists.")

--- a/Babylon/groups/api/groups/connector/commands/get_all.py
+++ b/Babylon/groups/api/groups/connector/commands/get_all.py
@@ -1,0 +1,69 @@
+import json
+from logging import getLogger
+from pprint import pformat
+from typing import Optional
+
+from click import command, make_pass_decorator, option
+from cosmotech_api.api.connector_api import ConnectorApi
+from cosmotech_api.exceptions import UnauthorizedException
+
+from ......utils.api import convert_keys_case, filter_api_response, underscore_to_camel
+from ......utils.decorators import allow_dry_run, timing_decorator
+
+logger = getLogger("Babylon")
+
+pass_connector_api = make_pass_decorator(ConnectorApi)
+
+
+@command()
+@allow_dry_run
+@timing_decorator
+@pass_connector_api
+@option(
+    "-o",
+    "--output_file",
+    "output_file",
+    help="File to which content should be outputted (json-formatted)",
+    type=str,
+)
+@option(
+    "-f",
+    "--fields",
+    "fields",
+    required=False,
+    type=str,
+    help="Fields witch will be keep in response data, by default all",
+)
+def get_all(
+    connector_api: ConnectorApi,
+    output_file: Optional[str] = None,
+    fields: str = None,
+    dry_run: bool = False,
+):
+    """Get all registered connector."""
+    try:
+        if dry_run:
+            logger.info("DRY RUN - Would call connector_api.find_all_connectors")
+            retrieved_connectors = [{"Babylon": "<DRY RUN>"}]
+        else:
+            retrieved_connectors = connector_api.find_all_connectors()
+            if fields is not None:
+                retrieved_connectors = filter_api_response(
+                    retrieved_connectors, fields.split(",")
+                )
+        if output_file is not None:
+            _connectors_to_dump = []
+            for _ele in retrieved_connectors:
+                converted_content = convert_keys_case(
+                    _ele.to_dict(), underscore_to_camel
+                )
+                _connectors_to_dump.append(converted_content)
+            with open(output_file, "w") as _file:
+                json.dump(_connectors_to_dump, _file, ensure_ascii=False)
+            logger.info(f"{len(_connectors_to_dump)} Connectors found")
+            logger.info(f"Full content was dumped on {output_file}")
+        else:
+            logger.info(pformat(retrieved_connectors))
+            logger.info(f"Found {len(retrieved_connectors)} connectors")
+    except UnauthorizedException:
+        logger.error("Unauthorized access to the cosmotech api")

--- a/Babylon/groups/api/groups/connector/groups/__init__.py
+++ b/Babylon/groups/api/groups/connector/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/templates/working_dir_template/API/ADT_Connector.yaml
+++ b/Babylon/templates/working_dir_template/API/ADT_Connector.yaml
@@ -1,0 +1,25 @@
+key:
+name:
+repository: cosmo-tech/azure-digital-twins-simulator-connector
+version: 2.4.0
+azureAuthenticationWithCustomerAppRegistration: true
+ioTypes:
+  - read
+description: Connector for Azure Digital Twins. Read ADT and write the data in CSV for a ScenarioRun
+tags:
+  - ADT
+url: https://github.com/Cosmo-Tech/azure-digital-twins-simulator-connector
+parameterGroups:
+  - id: parameters
+    label: Parameters
+    parameters:
+      - id: AZURE_DIGITAL_TWINS_URL
+        label: Azure Digital Twins URL
+        valueType: string
+        envVar: AZURE_DIGITAL_TWINS_URL
+      - id: CSM_NUMBER_OF_THREAD
+        label: Number of thread used
+        valueType: int
+        options: null
+        default: '1'
+        envVar: CSM_NUMBER_OF_THREAD

--- a/Babylon/templates/working_dir_template/API/Azure_Storage_Connector.yaml
+++ b/Babylon/templates/working_dir_template/API/Azure_Storage_Connector.yaml
@@ -1,0 +1,23 @@
+key: 
+name: 
+description: Connector for Azure Storage. Read all data in a container with a prefix and write the data in CSV for a ScenarioRun
+repository: cosmo-tech/azure-storage-simulator-connector
+version: 1.1.2
+tags:
+  - Azure Storage
+url: https://github.com/Cosmo-Tech/azure-storage-simulator-connector
+ioTypes:
+  - read
+parameterGroups:
+  - id: parameters
+    label: Parameters
+    parameters:
+      - id: AZURE_STORAGE_CONNECTION_STRING
+        label: Azure Storage Connection String
+        valueType: string
+        default: "%STORAGE_CONNECTION_STRING%"
+        envVar: AZURE_STORAGE_CONNECTION_STRING
+      - id: AZURE_STORAGE_CONTAINER_BLOB_PREFIX
+        label: Azure Storage Path in the form container/path
+        valueType: string
+        envVar: AZURE_STORAGE_CONTAINER_BLOB_PREFIX

--- a/Babylon/templates/working_dir_template/API/Connector.ADT.yaml
+++ b/Babylon/templates/working_dir_template/API/Connector.ADT.yaml
@@ -1,7 +1,7 @@
 key:
 name:
 repository: cosmo-tech/azure-digital-twins-simulator-connector
-version: 2.4.0
+version:
 azureAuthenticationWithCustomerAppRegistration: true
 ioTypes:
   - read

--- a/Babylon/templates/working_dir_template/API/Connector.STORAGE.yaml
+++ b/Babylon/templates/working_dir_template/API/Connector.STORAGE.yaml
@@ -1,8 +1,8 @@
-key: 
-name: 
+key:
+name:
 description: Connector for Azure Storage. Read all data in a container with a prefix and write the data in CSV for a ScenarioRun
 repository: cosmo-tech/azure-storage-simulator-connector
-version: 1.1.2
+version:
 tags:
   - Azure Storage
 url: https://github.com/Cosmo-Tech/azure-storage-simulator-connector

--- a/Babylon/utils/api.py
+++ b/Babylon/utils/api.py
@@ -5,7 +5,7 @@ import re
 import click
 from .environment import Environment
 
-from typing import Any
+from typing import Any, Iterable
 
 import yaml
 
@@ -58,6 +58,32 @@ def convert_keys_case(element: Any, convert_function) -> Any:
             new_element.append(convert_keys_case(e, convert_function))
         return new_element
     return element
+
+
+def filter_api_response_item(api_response_body: Any, fields: Iterable[str]) -> Any:
+    """
+    This function allow to apply a filter on an api unique response body keys
+    :param api_response_body: A single api response data in key=>value format
+    :param fields: A Set of keys witch will be keep in the response
+    :return None if api_response_body is empty or if the keys specified in fields parameter don't exist, else the filtered response data
+    """
+    filtered_ele = {}
+    _api_response_body = api_response_body.to_dict()
+    for _key, _value in _api_response_body.items():
+        if _key in fields:
+            filtered_ele[_key] = _value
+
+    return filtered_ele
+
+
+def filter_api_response(api_response_body: Iterable, fields: Iterable[str]) -> Any:
+    """
+    This function allow to apply a filter on an api response list body keys
+    :param api_response_body: A Set api response data in key=>value format
+    :param fields: A Set of keys witch will be keep in the response
+    :return None if api_response_body is empty or if the keys specified in fields parameter don't exist, else the filtered response data
+    """
+    return [filter_api_response_item(ele, fields) for ele in api_response_body]
 
 
 def get_api_file(api_file_path: str, use_working_dir_file: bool, logger):

--- a/Babylon/utils/configuration.py
+++ b/Babylon/utils/configuration.py
@@ -12,8 +12,7 @@ import click
 import yaml
 
 from . import TEMPLATE_FOLDER_PATH
-from .yaml_utils import read_yaml_key
-
+from .yaml_utils import read_yaml_key, write_yaml_value
 
 class Configuration:
     """
@@ -285,6 +284,28 @@ class Configuration:
             return None
         else:
             return read_yaml_key(_path, var_name)
+
+    def set_deploy_var(self, var_name, var_value) -> None:
+        """
+        Set key value in current deployment configuration file
+        :param var_name: the key to set
+        :param var_value: the value to assign
+        """
+        if not (_path := self.get_deploy_path()).exists():
+            pass
+        else:
+            write_yaml_value(_path, var_name, var_value)
+
+    def set_platform_var(self, var_name, var_value) -> None:
+        """
+        Set key value in current platform configuration file
+        :param var_name: the key to set
+        :param var_value: the value to assign
+        """
+        if not (_path := self.get_platform_path()).exists():
+            pass
+        else:
+            write_yaml_value(_path, var_name, var_value)
 
     def check_api(self) -> bool:
         """

--- a/Babylon/utils/yaml_utils.py
+++ b/Babylon/utils/yaml_utils.py
@@ -2,6 +2,7 @@ import pathlib
 from typing import Optional
 
 import yaml
+from ruamel.yaml import YAML #Allow to load and dump Yaml file with comment
 
 
 def read_yaml_key(yaml_file: pathlib.Path, key: str) -> Optional[object]:
@@ -18,6 +19,21 @@ def read_yaml_key(yaml_file: pathlib.Path, key: str) -> Optional[object]:
     except:
         return None
 
+def write_yaml_value(yaml_file: pathlib.Path, key: str, value: str) -> None:
+    """
+    This function aloow to update a YAML file values
+    :param yaml_file: path to the file to open
+    :param key: key to load
+    :param value:the new value of the key
+    :return : None
+    """
+    _commented_yaml_loader = YAML()
+    try:
+        _y = _commented_yaml_loader.load(yaml_file.open(mode='r'))
+        _y[key] = value
+        _commented_yaml_loader.dump(_y, yaml_file)
+    except OSError:
+        pass
 
 def compare_yaml_keys(template_yaml: pathlib.Path, target_yaml: pathlib.Path) -> tuple[set, set]:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyyaml
 
 # Testing requirements
 pytest
+ruamel.yaml
 
 # Documentation generation requirements
 mkdocs

--- a/tests/api_files/ADT_Connector.yaml
+++ b/tests/api_files/ADT_Connector.yaml
@@ -1,0 +1,25 @@
+key: ADT Connector
+name: ADT Connector
+repository: cosmo-tech/azure-digital-twins-simulator-connector
+version: 2.4.0
+azureAuthenticationWithCustomerAppRegistration: true
+ioTypes:
+  - read
+description: Connector for Azure Digital Twins. Read ADT and write the data in CSV for a ScenarioRun
+tags:
+  - ADT
+url: https://github.com/Cosmo-Tech/azure-digital-twins-simulator-connector
+parameterGroups:
+  - id: parameters
+    label: Parameters
+    parameters:
+      - id: AZURE_DIGITAL_TWINS_URL
+        label: Azure Digital Twins URL
+        valueType: string
+        envVar: AZURE_DIGITAL_TWINS_URL
+      - id: CSM_NUMBER_OF_THREAD
+        label: Number of thread used
+        valueType: int
+        options: null
+        default: '1'
+        envVar: CSM_NUMBER_OF_THREAD

--- a/tests/api_files/Azure_Storage_Connector.yaml
+++ b/tests/api_files/Azure_Storage_Connector.yaml
@@ -1,0 +1,23 @@
+key: AzureStorageConnector
+name: Azure Storage Connector
+description: Connector for Azure Storage. Read all data in a container with a prefix and write the data in CSV for a ScenarioRun
+repository: cosmo-tech/azure-storage-simulator-connector
+version: 1.1.2
+tags:
+  - Azure Storage
+url: https://github.com/Cosmo-Tech/azure-storage-simulator-connector
+ioTypes:
+  - read
+parameterGroups:
+  - id: parameters
+    label: Parameters
+    parameters:
+      - id: AZURE_STORAGE_CONNECTION_STRING
+        label: Azure Storage Connection String
+        valueType: string
+        default: "%STORAGE_CONNECTION_STRING%"
+        envVar: AZURE_STORAGE_CONNECTION_STRING
+      - id: AZURE_STORAGE_CONTAINER_BLOB_PREFIX
+        label: Azure Storage Path in the form container/path
+        valueType: string
+        envVar: AZURE_STORAGE_CONTAINER_BLOB_PREFIX


### PR DESCRIPTION
# How to test  api Connector commands

## Babylon installation

Follow Babylon documentation for installation

`Note:if you have already install Babylone one` you should update your python environnement by executing `pip install . -e` because we added a new python package in requirement.

Then set an Babylon Platform configuration

## API Connector Commands

### Get All

`babylon api connector get-all`

Should print all registred connector

### Create

`babylon api connector create  -v 1.1.18 -t STORAGE -n "Babylon Storage Test Connector"`

Sould register a new connctor whith version:1.1.18, name:Babylon Storage Test Connector, key:BabylonStorageTestConnector with template Babylon/templates/working_dir_template/API/Connector.STORAGE.yaml



