### PR TITLE
Adding adx permission operations

### DIFF
--- a/Babylon/groups/azure/groups/adx/groups/__init__.py
+++ b/Babylon/groups/azure/groups/adx/groups/__init__.py
@@ -1,3 +1,5 @@
+from .permission import permission
 
 list_groups = [
+    permission,
 ]

--- a/Babylon/groups/azure/groups/adx/groups/permission/__init__.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/__init__.py
@@ -9,7 +9,7 @@ from .groups import list_groups
 @group()
 @pass_context
 def permission(ctx: Context):
-    """Group initialized from a template"""
+    """Group interacting with ADX permissions"""
     pass
 
 

--- a/Babylon/groups/azure/groups/adx/groups/permission/__init__.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def permission(ctx: Context):
+    """Group initialized from a template"""
+    pass
+
+
+for _command in list_commands:
+    permission.add_command(_command)
+
+for _group in list_groups:
+    permission.add_command(_group)

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/__init__.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/__init__.py
@@ -1,0 +1,11 @@
+from .delete import delete
+from .set import set
+from .get_all import get_all
+from .get import get
+
+list_commands = [
+    delete,
+    set,
+    get_all,
+    get,
+]

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
@@ -1,0 +1,63 @@
+import logging
+
+from azure.mgmt.kusto import KustoManagementClient
+from click import argument
+from click import command
+from click import confirm
+from click import Context
+from click import option
+from click import pass_context
+
+from ........utils.decorators import allow_dry_run
+from ........utils.decorators import require_deployment_key
+from ........utils.decorators import require_platform_key
+
+logger = logging.getLogger("Babylon")
+"""Command Tests
+> babylon azure adx permission delete "existing_principal_id"
+Should ask confirmation, try y and no
+> babylon azure adx permission delete "unknown_principal_id"
+Should log a clean error message
+"""
+
+
+@command()
+@pass_context
+@require_platform_key("resource_group_name", "resource_group_name")
+@require_platform_key("cluster_name", "cluster_name")
+@require_deployment_key("database_name", "database_name")
+@argument("principal_id")
+@option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
+@allow_dry_run
+def delete(ctx: Context,
+           resource_group_name: str,
+           cluster_name: str,
+           database_name: str,
+           principal_id: str,
+           dry_run: bool,
+           force: bool = False):
+    """Delete all permission assignments applied to the given principal id"""
+    kusto_mgmt: KustoManagementClient = ctx.obj
+    assignments = kusto_mgmt.database_principal_assignments.list(resource_group_name, cluster_name, database_name)
+    entity_assignments = [assign for assign in assignments if assign.principal_id == principal_id]
+    if not entity_assignments:
+        logger.error(f"No assignment found for principal ID {principal_id}")
+        return
+
+    logger.info(f"Found {len(entity_assignments)} assignments for principal ID {principal_id}")
+    for assign in entity_assignments:
+        if not force and not confirm(
+                f"Do you confirm deletion of {assign.role} permission for {assign.principal_name} ?"):
+            logger.info(
+                f"Aborting deletion of role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
+            continue
+
+        if dry_run:
+            logger.info(f"Deleting role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
+            continue
+
+        assign_name: str = str(assign.name).split("/")[-1]
+        kusto_mgmt.database_principal_assignments.begin_delete(resource_group_name,
+                                                               cluster_name,
+                                                               database_name,
+                                                               principal_assignment_name=assign_name)

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
@@ -26,7 +26,7 @@ Should log a clean error message
 @require_platform_key("resource_group_name", "resource_group_name")
 @require_platform_key("cluster_name", "cluster_name")
 @require_deployment_key("database_name", "database_name")
-@argument("principal_id")
+@argument("principal_id", type=str)
 @option("-f", "--force", is_flag=True, help="Don't ask for validation before delete")
 @allow_dry_run
 def delete(ctx: Context,
@@ -52,11 +52,12 @@ def delete(ctx: Context,
                 f"Aborting deletion of role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
             continue
 
-        logger.info(f"Deleting role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
-
         if dry_run:
+            logger.info(
+                f"DRY RUN - Would delete role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
             continue
 
+        logger.info(f"Deleting role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
         assign_name: str = str(assign.name).split("/")[-1]
         kusto_mgmt.database_principal_assignments.begin_delete(resource_group_name,
                                                                cluster_name,

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
@@ -27,7 +27,7 @@ Should log a clean error message
 @require_platform_key("cluster_name", "cluster_name")
 @require_deployment_key("database_name", "database_name")
 @argument("principal_id")
-@option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
+@option("-f", "--force", is_flag=True, help="Don't ask for validation before delete")
 @allow_dry_run
 def delete(ctx: Context,
            resource_group_name: str,

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/delete.py
@@ -52,8 +52,9 @@ def delete(ctx: Context,
                 f"Aborting deletion of role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
             continue
 
+        logger.info(f"Deleting role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
+
         if dry_run:
-            logger.info(f"Deleting role {assign.role} to principal {assign.principal_type}:{assign.principal_id}")
             continue
 
         assign_name: str = str(assign.name).split("/")[-1]

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
@@ -1,0 +1,37 @@
+import logging
+
+from azure.mgmt.kusto import KustoManagementClient
+from click import argument
+from click import command
+from click import Context
+from click import pass_context
+from pprint import pformat
+
+from ........utils.decorators import require_platform_key, require_deployment_key
+
+logger = logging.getLogger("Babylon")
+"""Command Tests
+> babylon azure adx permission get "existing_principal_id"
+Should return the principal assignments
+> babylon azure adx permission get "unknown_principal_id"
+Should log a clean error message
+"""
+
+
+@command()
+@pass_context
+@require_platform_key("resource_group_name", "resource_group_name")
+@require_platform_key("cluster_name", "cluster_name")
+@require_deployment_key("database_name", "database_name")
+@argument("principal_id")
+def get(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str, principal_id: str):
+    """Get permission assignments applied to the given principal id"""
+    kusto_mgmt: KustoManagementClient = ctx.obj
+    assignments = kusto_mgmt.database_principal_assignments.list(resource_group_name, cluster_name, database_name)
+    entity_assignments = [assignment for assignment in assignments if assignment.principal_id == principal_id]
+    if not entity_assignments:
+        logger.error(f"No assignment found for principal ID {principal_id}")
+        return
+    logger.info(f"Found {len(entity_assignments)} assignments for principal ID {principal_id}")
+    for ent in entity_assignments:
+        logger.info(f"{pformat(ent.__dict__)}")

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
@@ -23,7 +23,7 @@ Should log a clean error message
 @require_platform_key("resource_group_name", "resource_group_name")
 @require_platform_key("cluster_name", "cluster_name")
 @require_deployment_key("database_name", "database_name")
-@argument("principal_id")
+@argument("principal_id", type=str)
 def get(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str, principal_id: str):
     """Get permission assignments applied to the given principal id"""
     kusto_mgmt: KustoManagementClient = ctx.obj

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/get.py
@@ -30,7 +30,7 @@ def get(ctx: Context, resource_group_name: str, cluster_name: str, database_name
     assignments = kusto_mgmt.database_principal_assignments.list(resource_group_name, cluster_name, database_name)
     entity_assignments = [assignment for assignment in assignments if assignment.principal_id == principal_id]
     if not entity_assignments:
-        logger.error(f"No assignment found for principal ID {principal_id}")
+        logger.info(f"No assignment found for principal ID {principal_id}")
         return
     logger.info(f"Found {len(entity_assignments)} assignments for principal ID {principal_id}")
     for ent in entity_assignments:

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/get_all.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/get_all.py
@@ -1,0 +1,29 @@
+import logging
+
+from azure.mgmt.kusto import KustoManagementClient
+from click import command
+from click import Context
+from click import pass_context
+from pprint import pformat
+
+from ........utils.decorators import require_platform_key, require_deployment_key
+
+logger = logging.getLogger("Babylon")
+"""Command Tests
+> babylon azure adx permission get-all
+Should list all available assignments
+"""
+
+
+@command()
+@pass_context
+@require_platform_key("resource_group_name", "resource_group_name")
+@require_platform_key("cluster_name", "cluster_name")
+@require_deployment_key("database_name", "database_name")
+def get_all(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str):
+    """Get all permission assignments in the database"""
+    kusto_mgmt: KustoManagementClient = ctx.obj
+    logger.info("Getting assignments...")
+    assignments = kusto_mgmt.database_principal_assignments.list(resource_group_name, cluster_name, database_name)
+    for ent in assignments:
+        logger.info(f"{pformat(ent.__dict__)}")

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -48,7 +48,7 @@ Should log a clean error message
 @allow_dry_run
 def set(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str, principal_id: str, role: str,
         principal_type: str, dry_run: bool):
-    """Command created from a template"""
+    """Get permission assignments applied to the given principal id"""
     kusto_mgmt: KustoManagementClient = ctx.obj
     parameters = DatabasePrincipalAssignment(principal_id=principal_id, principal_type=principal_type, role=role)
     principal_assignment_name = str(uuid4())

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -32,7 +32,7 @@ Should log a clean error message
 @require_platform_key("resource_group_name", "resource_group_name")
 @require_platform_key("cluster_name", "cluster_name")
 @require_deployment_key("database_name", "database_name")
-@argument("principal_id")
+@argument("principal_id", type=str)
 @option("-r",
         "--role",
         type=Choice(["User", "Viewer", "Admin"], case_sensitive=False),
@@ -53,7 +53,7 @@ def set(ctx: Context, resource_group_name: str, cluster_name: str, database_name
     logger.info("Creating assignment...")
 
     if dry_run:
-        logger.info(f"Adding role {role} to principal {principal_type}:{principal_id}")
+        logger.info(f"DRY RUN - Would add role {role} to principal {principal_type}:{principal_id}")
         return
 
     kusto_mgmt.database_principal_assignments.begin_create_or_update(resource_group_name, cluster_name, database_name,

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -35,13 +35,11 @@ Should log a clean error message
 @argument("principal_id")
 @option("-r",
         "--role",
-        "role",
         type=Choice(["User", "Viewer", "Admin"], case_sensitive=False),
         required=True,
         help="Assignment Role to Add")
 @option("-t",
         "--principal-type",
-        "principal-type",
         type=Choice(["User", "Group", "App"], case_sensitive=False),
         required=True,
         help="Principal type of the given ID")

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -50,7 +50,7 @@ def set(ctx: Context, resource_group_name: str, cluster_name: str, database_name
     kusto_mgmt: KustoManagementClient = ctx.obj
     parameters = DatabasePrincipalAssignment(principal_id=principal_id, principal_type=principal_type, role=role)
     principal_assignment_name = str(uuid4())
-    logging.info("Creating assignment...")
+    logger.info("Creating assignment...")
 
     if dry_run:
         logger.info(f"Adding role {role} to principal {principal_type}:{principal_id}")

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -1,0 +1,63 @@
+import logging
+
+from azure.mgmt.kusto import KustoManagementClient
+from azure.mgmt.kusto.models import DatabasePrincipalAssignment
+from click import argument
+from click import Choice
+from click import command
+from click import Context
+from click import option
+from click import pass_context
+from uuid import uuid4
+
+from ........utils.decorators import require_platform_key
+from ........utils.decorators import require_deployment_key
+from ........utils.decorators import allow_dry_run
+
+logger = logging.getLogger("Babylon")
+"""Command Tests
+> babylon azure adx permission set "existing_principal_id" -r Viewer
+Should ask for the missing principal type
+> babylon azure adx permission set "existing_principal_id" -t App
+Should ask for the missing principal role
+> babylon azure adx permission set "existing_principal_id" -t App -r Viewer
+Should ask for the missing principal role
+> babylon azure adx permission set "unknown_principal_id" -t App -r Viewer
+Should log a clean error message
+"""
+
+
+@command()
+@pass_context
+@require_platform_key("resource_group_name", "resource_group_name")
+@require_platform_key("cluster_name", "cluster_name")
+@require_deployment_key("database_name", "database_name")
+@argument("principal_id")
+@option("-r",
+        "--role",
+        "role",
+        type=Choice(["User", "Viewer", "Admin"], case_sensitive=False),
+        required=True,
+        help="Assignment Role to Add")
+@option("-t",
+        "--principal-type",
+        "principal-type",
+        type=Choice(["User", "Group", "App"], case_sensitive=False),
+        required=True,
+        help="Principal type of the given ID")
+@allow_dry_run
+def set(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str, principal_id: str, role: str,
+        principal_type: str, dry_run: bool):
+    """Command created from a template"""
+    kusto_mgmt: KustoManagementClient = ctx.obj
+    parameters = DatabasePrincipalAssignment(principal_id=principal_id, principal_type=principal_type, role=role)
+    principal_assignment_name = str(uuid4())
+    logging.info("Creating assignment...")
+
+    if dry_run:
+        logger.info(f"Adding role {role} to principal {principal_type}:{principal_id}")
+        return
+
+    kusto_mgmt.database_principal_assignments.begin_create_or_update(resource_group_name, cluster_name, database_name,
+                                                                     principal_assignment_name, parameters)
+    logger.info(f"Successfully created a new {role} assignment to {principal_type} {principal_id}")

--- a/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/commands/set.py
@@ -46,7 +46,7 @@ Should log a clean error message
 @allow_dry_run
 def set(ctx: Context, resource_group_name: str, cluster_name: str, database_name: str, principal_id: str, role: str,
         principal_type: str, dry_run: bool):
-    """Get permission assignments applied to the given principal id"""
+    """Set permission assignments applied to the given principal id"""
     kusto_mgmt: KustoManagementClient = ctx.obj
     parameters = DatabasePrincipalAssignment(principal_id=principal_id, principal_type=principal_type, role=role)
     principal_assignment_name = str(uuid4())

--- a/Babylon/groups/azure/groups/adx/groups/permission/groups/__init__.py
+++ b/Babylon/groups/azure/groups/adx/groups/permission/groups/__init__.py
@@ -1,0 +1,1 @@
+list_groups = []


### PR DESCRIPTION
### Command tests
#### Get all
```console
babylon azure adx permission get-all
```
Should list all available assignments
#### Get
```console
babylon azure adx permission get "existing_principal_id"
```
Should return the principal assignments
```console
babylon azure adx permission get "unknown_principal_id"
```
Should log a clean error message
#### Set
```console
 babylon azure adx permission set "existing_principal_id" -r Viewer
```
Should ask for the missing principal type
```console
 babylon azure adx permission set "existing_principal_id" -t App
```
Should ask for the missing principal role
```console
babylon azure adx permission set "existing_principal_id" -t App -r Viewer
```
Should ask for the missing principal role
```console
babylon azure adx permission set "unknown_principal_id" -t App -r Viewer
```
Should log a clean error message
#### Delete
```console
babylon azure adx permission delete "existing_principal_id"
```
Should ask confirmation, try y and no
```console
babylon azure adx permission delete "unknown_principal_id"
```
Should log a clean error message