### PR TITLE
moved ACR registry to a platform key

### DIFF
--- a/Babylon/groups/azure/groups/acr/commands/ls.py
+++ b/Babylon/groups/azure/groups/acr/commands/ls.py
@@ -8,7 +8,7 @@ from click import Context
 from click import option
 from click import pass_context
 
-from ......utils.decorators import require_deployment_key
+from ......utils.decorators import require_platform_key
 
 logger = logging.getLogger("Babylon")
 """Command Tests
@@ -22,11 +22,11 @@ Can be checked against `az acr repository list --name my_registry --output table
 
 @command()
 @pass_context
-@require_deployment_key("acr_src_registry_name", "acr_src_registry_name")
+@require_platform_key("acr_registry_name", "acr_registry_name")
 @option("-r", "--registry", help="Container Registry name to scan, example: myregistry.azurecr.io")
-def ls(ctx: Context, acr_src_registry_name: str, registry: typing.Optional[str]):
+def ls(ctx: Context, acr_registry_name: str, registry: typing.Optional[str]):
     """List all docker images in the specified registry"""
-    registry = registry or acr_src_registry_name
+    registry = registry or acr_registry_name
     # Login to registry
     response = subprocess.run(["az", "acr", "login", "--name", registry],
                               shell=False,

--- a/Babylon/groups/azure/groups/acr/commands/pull.py
+++ b/Babylon/groups/azure/groups/acr/commands/pull.py
@@ -8,9 +8,8 @@ from click import Context
 from click import option
 from click import pass_context
 import docker
-from docker import errors as dock_errors
 
-from ......utils.decorators import require_deployment_key
+from ......utils.decorators import require_deployment_key, require_platform_key
 
 logger = logging.getLogger("Babylon")
 """Command Tests
@@ -25,14 +24,14 @@ Should add new entry to `docker image ls`
 
 @command()
 @pass_context
-@require_deployment_key("acr_src_registry_name", "acr_src_registry_name")
+@require_platform_key("acr_registry_name", "acr_registry_name")
 @require_deployment_key("acr_image_reference", "acr_image_reference")
 @option("-i", "--image", help="Local docker image to pull")
 @option("-r", "--registry", help="Container Registry name to pull from, example: myregistry.azurecr.io")
-def pull(ctx: Context, acr_src_registry_name: str, acr_image_reference: str, registry: typing.Optional[str],
+def pull(ctx: Context, acr_registry_name: str, acr_image_reference: str, registry: typing.Optional[str],
          image: typing.Optional[str]):
     """Pulls a docker image from the ACR registry given in deployment configuration"""
-    registry = registry or acr_src_registry_name
+    registry = registry or acr_registry_name
     image = image or acr_image_reference
     # Login to registry
     response = subprocess.run(["az", "acr", "login", "--name", registry],
@@ -50,7 +49,7 @@ def pull(ctx: Context, acr_src_registry_name: str, acr_image_reference: str, reg
     repo = f"{registry}/{image}"
     try:
         client.images.pull(repository=repo)
-    except dock_errors.NotFound:
+    except docker.errors.NotFound:
         logger.error(f"Registry {registry} does not contain {image}")
-    except dock_errors.APIError as api_error:
+    except docker.errors.APIError as api_error:
         logger.error(f"API Error: {api_error}")

--- a/Babylon/groups/azure/groups/acr/commands/push.py
+++ b/Babylon/groups/azure/groups/acr/commands/push.py
@@ -11,7 +11,7 @@ from click import pass_context
 from click import option
 import docker
 
-from ......utils.decorators import require_deployment_key
+from ......utils.decorators import require_deployment_key, require_platform_key
 
 logger = logging.getLogger("Babylon")
 
@@ -32,14 +32,14 @@ Should a new entry to `az acr repository list --name my_registry` with the value
 
 @command()
 @pass_context
-@require_deployment_key("acr_dest_registry_name", "acr_dest_registry_name")
+@require_platform_key("acr_registry_name", "acr_registry_name")
 @require_deployment_key("acr_image_reference", "acr_image_reference")
 @option("-i", "--image", help="Local docker image to push")
 @option("-r", "--registry", help="Container Registry name to push to, example: myregistry.azurecr.io")
-def push(ctx: Context, acr_dest_registry_name: str, acr_image_reference: str, image: typing.Optional[str],
+def push(ctx: Context, acr_registry_name: str, acr_image_reference: str, image: typing.Optional[str],
          registry: typing.Optional[str]):
     """Push a docker image to the ACR registry given in deployment configuration"""
-    registry: str = registry or acr_dest_registry_name
+    registry: str = registry or acr_registry_name
     image: str = image or acr_image_reference
     # Login to registry
     response = subprocess.run(["az", "acr", "login", "--name", registry],

--- a/Babylon/templates/config_template/deployments/deploy.yaml
+++ b/Babylon/templates/config_template/deployments/deploy.yaml
@@ -10,9 +10,5 @@ api_url: ""
 database_name: ""
 # digital_twin_url : URL of the digital twin to use
 digital_twin_url: ""
-# ACR source registry name source_registry.azurecr.io)
-acr_src_registry_name: ""
-# ACR destination registry name destination_registry.azurecr.io)
-acr_dest_registry_name: ""
 # ACR image reference (my_repository:my_tag)
 acr_image_reference: ""

--- a/Babylon/templates/config_template/platforms/platform.yaml
+++ b/Babylon/templates/config_template/platforms/platform.yaml
@@ -13,3 +13,5 @@ azure_subscription: ""
 cluster_name: ""
 # resource_group_name: The name fo the resource group used on the platform
 resource_group_name: ""
+# ACR registry name source_registry.azurecr.io)
+acr_registry_name: ""


### PR DESCRIPTION
To test the new commands proceed as follow:
- install the new dependencies using `pip install -r requirements.txt`
- Add or edit the following lines in `config/platforms/platform.yml`
```yaml
# ACR registry name
acr_registry_name: "phoenixml.azurecr.io"
api_url: "https://dev.api.cosmotech.com"
api_scope: "http://dev.api.cosmotech.com/.default"
```
- Add or edit the following lines in `config/deployments/deploy.yml`
```yaml
# ACR image reference (repository:tag)
acr_image_reference: "hello-world:latest"
```
### ACR LS
```bash
babylon acr ls
```
Should list all images in the given registry
Can be checked against `az acr repository list --name my_registry --output table`

### ACR PUSH
Please first pull hello-world locally with `docker pull hello-world`
```bash
babylon acr push
```
Should add a new entry to `az acr repository list --name my_registry` with the `latest` tag

#### Clean
Clean the hello world image with
```bash
az acr repository delete -n phoenixml --repository hello-world
```

### ACR PULL
Please choose an existing image with `az acr repository list --name phoenixml --output table`
```bash
babylon acr pull this_image_does_not_exist
```
Should provide a clean error log
```bash
babylon acr pull existing_image -t existing_tag
```
Should add a new entry to `docker image ls`
```bash
babylon acr pull existing_image
```
Should a new entry to `docker image ls` with the latest tag

#### Clean
Clean docker images using
```bash
docker image ls
docker image rm image_id
```