### PR TITLE
After run of a script delete it from the ADX Cluster

### DIFF
--- a/Babylon/groups/azure/groups/adx/commands/run_script.py
+++ b/Babylon/groups/azure/groups/adx/commands/run_script.py
@@ -58,4 +58,10 @@ In the script instances of "<database name>" will be replaced by the actual data
         except HttpResponseError as _resp_error:
             logger.error(_resp_error.message.split("\nMessage:")[1])
         else:
+            kmc.scripts.begin_delete(
+                resource_group_name=resource_group_name,
+                cluster_name=cluster_name,
+                database_name=database_name,
+                script_name=script_name,
+            )
             logger.info("Script successfully ran.")


### PR DESCRIPTION
There is a 50 scripts limit on the cluster, and after their run there is no further use. 
So we added a deletion of the script at the end of the run.