### PR TITLE
PROD-10278: Storage blob containers create, delete, lists

### DIFF
--- a/Babylon/groups/azure/groups/__init__.py
+++ b/Babylon/groups/azure/groups/__init__.py
@@ -1,8 +1,10 @@
+from .storage_blob import storage_blob
 from .acr import acr
 from .adt import adt
 from .adx import adx
 
 list_groups = [
+    storage_blob,
     acr,
     adt,
     adx,

--- a/Babylon/groups/azure/groups/storage_blob/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/__init__.py
@@ -10,6 +10,7 @@ from .....utils.decorators import require_deployment_key
 
 logger = logging.getLogger()
 
+
 @group()
 @pass_context
 @require_deployment_key("storage_account_name", "storage_account_name")

--- a/Babylon/groups/azure/groups/storage_blob/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/__init__.py
@@ -2,22 +2,25 @@ import logging
 from azure.storage.blob import BlobServiceClient
 from click import group
 from click import pass_context
+from click import option
 from click.core import Context
 
 from .commands import list_commands
 from .groups import list_groups
 from .....utils.decorators import require_deployment_key
 
-logger = logging.getLogger()
+logger = logging.getLogger("Babylon")
 
 
 @group()
+@option("-a", "--account", "account", help="Storage account name")
 @pass_context
 @require_deployment_key("storage_account_name", "storage_account_name")
-def storage_blob(ctx: Context, storage_account_name: str):
+def storage_blob(ctx: Context, account: str, storage_account_name: str):
     """Group interacting with Azure Storage Blob"""
-    logger.info(f"Connecting to storage account '{storage_account_name}'")
-    account_url = f"https://{storage_account_name}.blob.core.windows.net"
+    account_name = account or storage_account_name
+    logger.debug(f"Connecting to storage account '{account_name}'")
+    account_url = f"https://{account_name}.blob.core.windows.net"
     blob_client = BlobServiceClient(account_url, ctx.parent.obj)
     ctx.obj = blob_client
 

--- a/Babylon/groups/azure/groups/storage_blob/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/__init__.py
@@ -1,0 +1,28 @@
+import logging
+from azure.storage.blob import BlobServiceClient
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+from .....utils.decorators import require_deployment_key
+
+logger = logging.getLogger()
+
+@group()
+@pass_context
+@require_deployment_key("storage_account_name", "storage_account_name")
+def storage_blob(ctx: Context, storage_account_name: str):
+    """Group interacting with Azure Storage Blob"""
+    logger.info(f"Connecting to storage account '{storage_account_name}'")
+    account_url = f"https://{storage_account_name}.blob.core.windows.net"
+    blob_client = BlobServiceClient(account_url, ctx.parent.obj)
+    ctx.obj = blob_client
+
+
+for _command in list_commands:
+    storage_blob.add_command(_command)
+
+for _group in list_groups:
+    storage_blob.add_command(_group)

--- a/Babylon/groups/azure/groups/storage_blob/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/__init__.py
@@ -14,13 +14,14 @@ logger = logging.getLogger("Babylon")
 
 @group()
 @option("-a", "--account", "account", help="Storage account name")
+@option("-u", "--url", "url", help="Storage account url")
 @pass_context
 @require_deployment_key("storage_account_name", "storage_account_name")
-def storage_blob(ctx: Context, account: str, storage_account_name: str):
+def storage_blob(ctx: Context, account: str, url: str, storage_account_name: str):
     """Group interacting with Azure Storage Blob"""
     account_name = account or storage_account_name
-    logger.debug(f"Connecting to storage account '{account_name}'")
-    account_url = f"https://{account_name}.blob.core.windows.net"
+    account_url = url or f"https://{account_name}.blob.core.windows.net"
+    logger.debug(f"Connecting to storage account '{account_url}'")
     blob_client = BlobServiceClient(account_url, ctx.parent.obj)
     ctx.obj = blob_client
 

--- a/Babylon/groups/azure/groups/storage_blob/commands/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/commands/__init__.py
@@ -1,0 +1,5 @@
+from .list import list
+
+list_commands = [
+    list,
+]

--- a/Babylon/groups/azure/groups/storage_blob/commands/list.py
+++ b/Babylon/groups/azure/groups/storage_blob/commands/list.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-from azure.core.exceptions import HttpResponseError
 from azure.storage.blob import BlobServiceClient
 from click import command
 from click import make_pass_decorator
@@ -14,7 +13,7 @@ pass_blobclient = make_pass_decorator(BlobServiceClient)
 @command()
 @pass_blobclient
 def list(blobclient: BlobServiceClient) -> Optional[str]:
-    """Creates a new storageblob container with the given name"""
+    """Lists storage containers from a given account"""
     logger.info(f"Listing containers from storage account {blobclient.account_name}")
     try:
         containers = blobclient.list_containers()

--- a/Babylon/groups/azure/groups/storage_blob/commands/list.py
+++ b/Babylon/groups/azure/groups/storage_blob/commands/list.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Optional
+
+from azure.core.exceptions import HttpResponseError
+from azure.storage.blob import BlobServiceClient
+from click import command
+from click import make_pass_decorator
+
+logger = logging.getLogger("Babylon")
+
+pass_blobclient = make_pass_decorator(BlobServiceClient)
+
+
+@command()
+@pass_blobclient
+def list(blobclient: BlobServiceClient) -> Optional[str]:
+    """Creates a new storageblob container with the given name"""
+    logger.info(f"Listing containers from storage account {blobclient.account_name}")
+    try:
+        containers = blobclient.list_containers()
+    except Exception as e:
+        logger.error(e.message)
+        return None
+    logger.info("Containers found:")
+    account_url = f"https://{blobclient.account_name}.blob.core.windows.net"
+    for container in containers:
+        logger.info(f"  - {container.name}: {account_url}/{container.name}")

--- a/Babylon/groups/azure/groups/storage_blob/groups/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/__init__.py
@@ -1,0 +1,5 @@
+from .container import container
+
+list_groups = [
+    container,
+]

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def container(ctx: Context):
+    """Group interacting with Azure Storage Blob containers"""
+    pass
+
+
+for _command in list_commands:
+    container.add_command(_command)
+
+for _group in list_groups:
+    container.add_command(_group)

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/commands/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/commands/__init__.py
@@ -1,0 +1,7 @@
+from .delete import delete
+from .create import create
+
+list_commands = [
+    delete,
+    create,
+]

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/commands/create.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/commands/create.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Optional
+
+from azure.core.exceptions import HttpResponseError
+from azure.storage.blob import BlobServiceClient
+from click import argument
+from click import command
+from click import make_pass_decorator
+
+logger = logging.getLogger("Babylon")
+
+pass_blobclient = make_pass_decorator(BlobServiceClient)
+
+
+@command()
+@pass_blobclient
+@argument("container_name")
+def create(blobclient: BlobServiceClient, container_name: str) -> Optional[str]:
+    """Creates a new storageblob container with the given name"""
+    logger.info(f"Creating container {container_name} in storage account {blobclient.account_name}")
+    try:
+        container = blobclient.create_container(container_name)
+    except HttpResponseError as e:
+        error_message = e.message.split("\n")
+        logging.error(f"Failed to create container '{container_name}': {error_message[0]}")
+        return
+    except Exception as e:
+        logger.error(e.message)
+        return
+
+    logger.info(f"Successfully created container {container_name}: {container.url}")
+    return container.url

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/commands/delete.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/commands/delete.py
@@ -19,7 +19,7 @@ pass_blobclient = make_pass_decorator(BlobServiceClient)
 @argument("container_name")
 @option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
 def delete(blobclient: BlobServiceClient, container_name: str, force_validation: bool = False):
-    """Creates a new storageblob container with the given name"""
+    """Deletes a storageblob container with the given name"""
     if not force_validation:
         if not confirm(f"You are trying to delete container {container_name} \nDo you want to continue ?"):
             logger.info("Container deletion aborted.")

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/commands/delete.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/commands/delete.py
@@ -1,0 +1,40 @@
+from azure.core.exceptions import HttpResponseError
+from azure.storage.blob import BlobServiceClient
+from click import argument
+from click import command
+from click import confirm
+from click import make_pass_decorator
+from click import option
+from click import prompt
+
+import logging
+
+logger = logging.getLogger("Babylon")
+
+pass_blobclient = make_pass_decorator(BlobServiceClient)
+
+
+@command()
+@pass_blobclient
+@argument("container_name")
+@option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
+def delete(blobclient: BlobServiceClient, container_name: str, force_validation: bool = False):
+    """Creates a new storageblob container with the given name"""
+    if not force_validation:
+        if not confirm(f"You are trying to delete container {container_name} \nDo you want to continue ?"):
+            logger.info("Container deletion aborted.")
+            return
+
+        confirm_container_name = prompt("Confirm Container name")
+        if confirm_container_name != container_name:
+            logger.error("Wrong Container name , "
+                         "the id must be the same as the one that has been provide in delete command argument")
+            return
+    try:
+        container = blobclient.get_container_client(container_name)
+        container.delete_container()
+    except HttpResponseError as e:
+        error_message = e.message.split("\n")
+        logging.error(f"Failed to delete container '{container_name}': {error_message[0]}")
+        return
+    logger.info(f"Successfully deleted container {container_name}")

--- a/Babylon/groups/azure/groups/storage_blob/groups/container/groups/__init__.py
+++ b/Babylon/groups/azure/groups/storage_blob/groups/container/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/templates/config_template/deployments/deploy.yaml
+++ b/Babylon/templates/config_template/deployments/deploy.yaml
@@ -12,3 +12,5 @@ database_name: ""
 digital_twin_url: ""
 # ACR image reference (my_repository:my_tag)
 acr_image_reference: ""
+# Storage account name
+storage_account_name: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ msrest
 # Azure services requirements
 azure-digitaltwins-core
 azure-containerregistry
+azure-storage-blob
 
 # Click requirements
 click


### PR DESCRIPTION
## Setup
Add the following line to your `deploy.yml` file 
```yaml
# Storage account name
storage_account_name: "trahcity2storageaccount"
```
Containers status can be checked with the following ``az cli`` command
```bash
az storage container list --account-name "trahcity2storageaccount" --output table
```
# Create container
```bash
babylon azure storage-blob container create test-container
```
Should successfully create the container and output its url
Creating an already existent container should display an explicit error

# List container
```bash
babylon azure storage-blob list
```
Should display the newly created container with it's url
```bash
babylon azure storage-blob --account [account_name] list
babylon azure storage-blob --url [account_url] list
```
It is possible to use the --account or --url option to specify another storage account

# Delete container
```bash
babylon azure storage-blob container delete test-container
```
Should ask for confirmation and delete the container
```bash
babylon azure storage-blob container delete test-container -f
```
Should delete without asking for confirmation
Deleting nonexistent containers should display an explicit error