### PR TITLE
Automate parameters handler upload

### DIFF
--- a/Babylon/groups/api/groups/solution/__init__.py
+++ b/Babylon/groups/api/groups/solution/__init__.py
@@ -4,8 +4,9 @@ from click import pass_context
 from click.core import Context
 from cosmotech_api.api.solution_api import SolutionApi
 
-from .commands import list_commands
 from .....utils.decorators import pass_api_configuration
+from .commands import list_commands
+from .groups import list_groups
 
 
 @group()
@@ -19,3 +20,6 @@ def solution(ctx: Context, api_configuration):
 
 for _command in list_commands:
     solution.add_command(_command)
+
+for _group in list_groups:
+    solution.add_command(_group)

--- a/Babylon/groups/api/groups/solution/groups/__init__.py
+++ b/Babylon/groups/api/groups/solution/groups/__init__.py
@@ -1,0 +1,4 @@
+from .handler import handler
+list_groups = [
+    handler,
+]

--- a/Babylon/groups/api/groups/solution/groups/handler/__init__.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/__init__.py
@@ -9,7 +9,7 @@ from .groups import list_groups
 @group()
 @pass_context
 def handler(ctx: Context):
-    """Group initialized from a template"""
+    """Group allowing solution handler management"""
     pass
 
 

--- a/Babylon/groups/api/groups/solution/groups/handler/__init__.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def handler(ctx: Context):
+    """Group initialized from a template"""
+    pass
+
+
+for _command in list_commands:
+    handler.add_command(_command)
+
+for _group in list_groups:
+    handler.add_command(_group)

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/__init__.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/__init__.py
@@ -1,0 +1,7 @@
+from .download import download
+from .upload import upload
+
+list_commands = [
+    download,
+    upload,
+]

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -24,14 +24,14 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @timing_decorator
 @pass_solution_api
 @option(
-    "-t",
+    "-r",
     "--run-template",
     "run_template_id",
     help="The run Template identifier",
     required=True,
 )
 @option(
-    "-h",
+    "-t",
     "--handler-type",
     "handler_id",
     type=Choice(
@@ -46,9 +46,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
         case_sensitive=False,
     ),
     required=True,
-    help="Handler type, allowed values\
-        :[parameters_handler, validator,\
-            prerun, engine, postrun, scenariodata_transform]",
+    help="Handler type",
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import IO
 from typing import Optional
 
 from click import Choice
@@ -10,10 +11,9 @@ from cosmotech_api.exceptions import NotFoundException
 from cosmotech_api.exceptions import ServiceException
 from cosmotech_api.exceptions import UnauthorizedException
 
-from ........utils.decorators import pass_environment
+from ........utils.decorators import describe_dry_run
 from ........utils.decorators import require_deployment_key
 from ........utils.decorators import timing_decorator
-from ........utils.environment import Environment
 
 logger = getLogger("Babylon")
 
@@ -23,7 +23,6 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @command()
 @timing_decorator
 @pass_solution_api
-@pass_environment
 @option(
     "-t",
     "--run-template",
@@ -53,27 +52,17 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")
-@option(
-    "-e",
-    "--use-working-dir-file",
-    "use_working_dir_file",
-    is_flag=True,
-    help="Should the path be relative to the working directory ?",
-)
+@describe_dry_run("Would call **solution_api.download_run_template_handler** to download a solution handler zip")
 def download(
-    env: Environment,
     solution_api: SolutionApi,
     organization_id: str,
     solution_id: str,
-    handler_path: str,
     handler_id: str,
     run_template_id: str,
-    use_working_dir_file: Optional[bool] = False,
-    dry_run: Optional[bool] = False,
 ) -> Optional[str]:
     """Send a JSON or YAML file to the API to create an solution."""
 
-    logger.info(f"Uploading {handler_id} handler to solution {solution_id}")
+    logger.info(f"Downloading {handler_id} handler from solution {solution_id}")
     try:
         response = solution_api.download_run_template_handler(
             organization_id=organization_id,
@@ -91,4 +80,11 @@ def download(
         logger.error(f"Organization with id {organization_id} and or Solution {solution_id} not found.")
         return
 
-    logger.info(response)
+    if not response:
+        logger.error("No retrieved handler")
+        return
+
+    with open(run_template_id + ".zip", "w") as _f:
+        IO.write(response, _f)
+
+    logger.info(f"{handler_id} handler downloaded from solution {solution_id} successfully")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -1,5 +1,4 @@
 from logging import getLogger
-from typing import IO
 from typing import Optional
 
 from click import Choice
@@ -82,7 +81,7 @@ def download(
         logger.error("No retrieved handler")
         return
 
-    with open(run_template_id + ".zip", "w") as _f:
+    with open(run_template_id + ".zip", "wb") as _f:
         _f.write(response.read())
 
     logger.debug(response)

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -83,7 +83,7 @@ def download(
         return
 
     with open(run_template_id + ".zip", "w") as _f:
-        IO.write(response, _f)
+        _f.write(response.read())
 
     logger.debug(response)
     logger.info(f"{handler_id} handler downloaded from solution {solution_id} successfully")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -48,7 +48,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
     required=True,
     help="Handler type, allowed values\
         :[parameters_handler, validator,\
-            prerun, engine, postrun, scenariodata_transform]",
+            prerun, engine, postrun, scenariodata_transform]"                                                             ,
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")
@@ -60,7 +60,7 @@ def download(
     handler_id: str,
     run_template_id: str,
 ) -> Optional[str]:
-    """Send a JSON or YAML file to the API to create an solution."""
+    """Download a solution handler zip."""
 
     logger.info(f"Downloading {handler_id} handler from solution {solution_id}")
     try:

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -50,9 +50,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")
-@describe_dry_run(
-    "Would call **solution_api.download_run_template_handler** to download a solution handler zip"
-)
+@describe_dry_run("Would call **solution_api.download_run_template_handler** to download a solution handler zip")
 def download(
     solution_api: SolutionApi,
     organization_id: str,

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -1,0 +1,11 @@
+import logging
+
+from click import command
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+def download():
+    """Command created from a template"""
+    logger.warning("This command was initialized from a template and is empty")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -48,7 +48,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
     required=True,
     help="Handler type, allowed values\
         :[parameters_handler, validator,\
-            prerun, engine, postrun, scenariodata_transform]"                                                             ,
+            prerun, engine, postrun, scenariodata_transform]",
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -1,11 +1,94 @@
-import logging
+from logging import getLogger
+from typing import Optional
 
+from click import Choice
 from click import command
+from click import make_pass_decorator
+from click import option
+from cosmotech_api.api.solution_api import SolutionApi
+from cosmotech_api.exceptions import NotFoundException
+from cosmotech_api.exceptions import ServiceException
+from cosmotech_api.exceptions import UnauthorizedException
 
-logger = logging.getLogger("Babylon")
+from ........utils.decorators import pass_environment
+from ........utils.decorators import require_deployment_key
+from ........utils.decorators import timing_decorator
+from ........utils.environment import Environment
+
+logger = getLogger("Babylon")
+
+pass_solution_api = make_pass_decorator(SolutionApi)
 
 
 @command()
-def download():
-    """Command created from a template"""
-    logger.warning("This command was initialized from a template and is empty")
+@timing_decorator
+@pass_solution_api
+@pass_environment
+@option(
+    "-t",
+    "--run-template",
+    "run_template_id",
+    help="The run Template identifier",
+    required=True,
+)
+@option(
+    "-h",
+    "--handler-type",
+    "handler_id",
+    type=Choice(
+        [
+            "parameters_handler",
+            "validator",
+            "prerun",
+            "engine",
+            "postrun",
+            "scenariodata_transform",
+        ],
+        case_sensitive=False,
+    ),
+    required=True,
+    help="Handler type, allowed values\
+        :[parameters_handler, validator,\
+            prerun, engine, postrun, scenariodata_transform]",
+)
+@require_deployment_key("organization_id", "organization_id")
+@require_deployment_key("solution_id", "solution_id")
+@option(
+    "-e",
+    "--use-working-dir-file",
+    "use_working_dir_file",
+    is_flag=True,
+    help="Should the path be relative to the working directory ?",
+)
+def download(
+    env: Environment,
+    solution_api: SolutionApi,
+    organization_id: str,
+    solution_id: str,
+    handler_path: str,
+    handler_id: str,
+    run_template_id: str,
+    use_working_dir_file: Optional[bool] = False,
+    dry_run: Optional[bool] = False,
+) -> Optional[str]:
+    """Send a JSON or YAML file to the API to create an solution."""
+
+    logger.info(f"Uploading {handler_id} handler to solution {solution_id}")
+    try:
+        response = solution_api.download_run_template_handler(
+            organization_id=organization_id,
+            solution_id=solution_id,
+            run_template_id=run_template_id,
+            handler_id=handler_id,
+        )
+    except UnauthorizedException:
+        logger.error("Unauthorized access to the cosmotech api")
+        return
+    except NotFoundException:
+        logger.error(f"Organization with id {organization_id} not found.")
+        return
+    except ServiceException:
+        logger.error(f"Organization with id {organization_id} and or Solution {solution_id} not found.")
+        return
+
+    logger.info(response)

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/download.py
@@ -50,7 +50,9 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")
-@describe_dry_run("Would call **solution_api.download_run_template_handler** to download a solution handler zip")
+@describe_dry_run(
+    "Would call **solution_api.download_run_template_handler** to download a solution handler zip"
+)
 def download(
     solution_api: SolutionApi,
     organization_id: str,
@@ -85,4 +87,5 @@ def download(
     with open(run_template_id + ".zip", "w") as _f:
         IO.write(response, _f)
 
+    logger.debug(response)
     logger.info(f"{handler_id} handler downloaded from solution {solution_id} successfully")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
@@ -1,0 +1,98 @@
+from logging import getLogger
+from typing import Optional
+
+from click import Choice
+from click import Path
+from click import argument
+from click import command
+from click import make_pass_decorator
+from click import option
+from cosmotech_api.api.solution_api import SolutionApi
+from cosmotech_api.exceptions import NotFoundException
+from cosmotech_api.exceptions import ServiceException
+from cosmotech_api.exceptions import UnauthorizedException
+
+from ........utils.decorators import allow_dry_run
+from ........utils.decorators import pass_environment
+from ........utils.decorators import require_deployment_key
+from ........utils.decorators import timing_decorator
+from ........utils.environment import Environment
+
+logger = getLogger("Babylon")
+
+pass_solution_api = make_pass_decorator(SolutionApi)
+
+
+@command()
+@allow_dry_run
+@timing_decorator
+@pass_solution_api
+@pass_environment
+@argument("handler-path", type=Path())
+@option(
+    "-t",
+    "--run-template",
+    "run_template_id",
+    help="The run Template identifier",
+    required=True,
+)
+@option(
+    "-h",
+    "--handler-type",
+    "handler_id",
+    type=Choice(
+        [
+            "parameters_handler",
+            "validator",
+            "prerun",
+            "engine",
+            "postrun",
+            "scenariodata_transform",
+        ],
+        case_sensitive=False,
+    ),
+    help="Handler type, allowed values\
+        :[parameters_handler, validator,\
+            prerun, engine, postrun, scenariodata_transform]",
+)
+@require_deployment_key("organization_id", "organization_id")
+@require_deployment_key("solution_id", "solution_id")
+@option(
+    "-e",
+    "--use-working-dir-file",
+    "use_working_dir_file",
+    is_flag=True,
+    help="Should the path be relative to the working directory ?",
+)
+def upload(
+    env: Environment,
+    solution_api: SolutionApi,
+    organization_id: str,
+    solution_id: str,
+    handler_path: str,
+    handler_id: str,
+    run_template_id: str,
+    use_working_dir_file: Optional[bool] = False,
+    dry_run: Optional[bool] = False,
+) -> Optional[str]:
+    """Send a JSON or YAML file to the API to create an solution."""
+
+    try:
+        handler = open(handler_path, 'rb')
+        _ = solution_api.upload_run_template_handler(
+            organization_id=organization_id,
+            solution_id=solution_id,
+            run_template_id=run_template_id,
+            handler_id=handler_id,
+            body=handler,
+        )
+    except UnauthorizedException:
+        logger.error("Unauthorized access to the cosmotech api")
+        return
+    except NotFoundException:
+        logger.error(f"Organization with id {organization_id} not found.")
+        return
+    except ServiceException:
+        logger.error(f"Organization with id {organization_id} and or Solution {solution_id} not found.")
+        return
+    logger.info("Created new solution with ")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
@@ -99,5 +99,5 @@ def upload(
         logger.error(f"An error occurred : { e.body}")
         return
 
-    logger.info(response)
+    logger.debug(response)
     logger.info(f"{handler_id} handler uploaded to solution {solution_id} successfully")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
@@ -9,10 +9,8 @@ from click import make_pass_decorator
 from click import option
 from cosmotech_api.api.solution_api import SolutionApi
 from cosmotech_api.exceptions import NotFoundException
-from cosmotech_api.exceptions import ServiceException
 from cosmotech_api.exceptions import UnauthorizedException
 
-from ........utils.decorators import allow_dry_run
 from ........utils.decorators import pass_environment
 from ........utils.decorators import require_deployment_key
 from ........utils.decorators import timing_decorator
@@ -24,7 +22,6 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 
 
 @command()
-@allow_dry_run
 @timing_decorator
 @pass_solution_api
 @pass_environment
@@ -51,6 +48,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
         ],
         case_sensitive=False,
     ),
+    required=True,
     help="Handler type, allowed values\
         :[parameters_handler, validator,\
             prerun, engine, postrun, scenariodata_transform]",
@@ -77,9 +75,11 @@ def upload(
 ) -> Optional[str]:
     """Send a JSON or YAML file to the API to create an solution."""
 
+    handler = open(handler_path, 'rb')
+
+    logger.info(f"Uploading {handler_id} handler to solution {solution_id}")
     try:
-        handler = open(handler_path, 'rb')
-        _ = solution_api.upload_run_template_handler(
+        response = solution_api.upload_run_template_handler(
             organization_id=organization_id,
             solution_id=solution_id,
             run_template_id=run_template_id,
@@ -92,7 +92,9 @@ def upload(
     except NotFoundException:
         logger.error(f"Organization with id {organization_id} not found.")
         return
-    except ServiceException:
-        logger.error(f"Organization with id {organization_id} and or Solution {solution_id} not found.")
-        return
-    logger.info("Created new solution with ")
+    # except ServiceException:
+    #     logger.error(f"Organization with id {organization_id} and or Solution {solution_id} not found.")
+    #     return
+
+    logger.info(response)
+    logger.info(f"{handler_id} handler uploaded to solution {solution_id} successfully")

--- a/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/commands/upload.py
@@ -28,14 +28,14 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @argument("handler-path", type=Path())
 @option("-o", "--override", "override", is_flag=True)
 @option(
-    "-t",
+    "-r",
     "--run-template",
     "run_template_id",
     help="The run Template identifier",
     required=True,
 )
 @option(
-    "-h",
+    "-t",
     "--handler-type",
     "handler_id",
     type=Choice(
@@ -50,9 +50,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
         case_sensitive=False,
     ),
     required=True,
-    help="Handler type, allowed values\
-        :[parameters_handler, validator,\
-            prerun, engine, postrun, scenariodata_transform]",
+    help="Handler type",
 )
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("solution_id", "solution_id")
@@ -66,7 +64,7 @@ def upload(
     run_template_id: str,
     override: Optional[bool] = False,
 ) -> Optional[str]:
-    """Send a JSON or YAML file to the API to create an solution."""
+    """Upload a solution handler zip."""
 
     if not handler_path.endswith(".zip"):
         logger.error(f"{handler_path} is not a zip archive")

--- a/Babylon/groups/api/groups/solution/groups/handler/groups/__init__.py
+++ b/Babylon/groups/api/groups/solution/groups/handler/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/version.py
+++ b/Babylon/version.py
@@ -1,4 +1,4 @@
-VERSION = '1.1.0'
+VERSION = '1.1.1'
 
 
 def get_version():


### PR DESCRIPTION
# Automate parameters handler upload

## Added api solution handler subgroup

## Usage: `babylon api solution handler [OPTIONS] COMMAND [ARGS]...`

## Options:
  `-h`, `--help`  Show help message and exit.

## Commands:
  `download`  Download a solution handler zip.
  `upload`    Upload a solution handler zip.

### download

#### Usage:  `babylon api solution handler download [OPTIONS] `

  Download a solution handler zip.

  Requires key `solution_id` in the deployment config file.

  Requires key `organization_id` in the deployment config file.

#### Options:
  -r, --run-template TEXT         The run Template identifier  [required]
  -t, --handler-type [parameters_handler|validator|prerun|engine|postrun|scenariodata_transform] Handler type  [required]
  -h, --help                               Show help message and exit.

### upload

#### Usage:   `babylon api solution handler upload [OPTIONS] HANDLER_PATH`

Upload a solution handler zip.

  Requires key `solution_id` in the deployment config file.

  Requires key `organization_id` in the deployment config file.

#### Options:
  -r, --run-template TEXT         The run Template identifier  [required]
  -t, --handler-type [parameters_handler|validator|prerun|engine|postrun|scenariodata_transform] Handler type  [required]
  -h, --help                               Show help message and exit.