### PR TITLE
Proof of Concept, macro commands

### DIFF
--- a/Babylon/commands/__init__.py
+++ b/Babylon/commands/__init__.py
@@ -1,3 +1,4 @@
-
+from .run import run
 list_commands = [
+    run
 ]

--- a/Babylon/commands/run.py
+++ b/Babylon/commands/run.py
@@ -40,6 +40,7 @@ def _insert_from_forward(step: dict[str, Any], data: dict[str, Any]) -> dict[str
         options[key] = data[fwd_k]
     return {**step, "arguments": arguments, "options": options}
 
+
 @click.command
 @click.pass_context
 @click.argument("script", type=click.Path(readable=True, dir_okay=False))

--- a/Babylon/commands/run.py
+++ b/Babylon/commands/run.py
@@ -18,8 +18,27 @@ def execute_step(root: click.Context, step: Dict[str, Any]):
         ["Babylon", "".join([f".groups.{group}" for group in commands[:-1]]), f".commands.{commands[-1]}"])
     command_module = import_module(to_import, "Babylon")
     cmd = getattr(command_module, commands[-1])
-    return root.invoke(cmd, **step.get("params", {}))
+    return root.invoke(cmd, *step.get("arguments", []), **step.get("options", {}))
 
+
+def _insert_from_forward(step: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+    # Inserting values for arguments
+    arguments = step.get("arguments", [])
+    for idx, argument in enumerate(arguments):
+        needle = re.match(r"\$\w+\$", argument)
+        if not needle:
+            continue
+        fwd_k = needle.group().replace("$", "")
+        arguments[idx] = data[fwd_k]
+    # Inserting values for options
+    options = step.get("options", {})
+    for key, option in options.items():
+        needle = re.match(r"\$\w+\$", option)
+        if not needle:
+            continue
+        fwd_k = needle.group().replace("$", "")
+        options[key] = data[fwd_k]
+    return {**step, "arguments": arguments, "options": options}
 
 @click.command
 @click.pass_context
@@ -35,18 +54,8 @@ def run(ctx: click.Context, script: str):
     root = ctx.find_root()
     forward_data = {}
     for step in macro.get("steps", []):
-
-        # Insert values from forward in parameters
-        for key, param in step.get("params", {}).items():
-            needle = re.match(r"\$\w+\$", param)
-            if not needle:
-                continue
-            fwd_k = needle.group().replace("$", "")
-            # Replacing variable symbol by its actual value
-            step["params"][key] = forward_data[fwd_k]
-
+        step = _insert_from_forward(step, forward_data)
         response: CommandResponse = execute_step(root, step)
-
         # Forwarding response data to next commands
         for fwd_k, data_k in step.get("forward", {}).items():
             forward_data[fwd_k] = jmespath.search(data_k, response.data)

--- a/Babylon/commands/run.py
+++ b/Babylon/commands/run.py
@@ -21,7 +21,7 @@ def execute_step(root: click.Context, step: Dict[str, Any]):
     return root.invoke(cmd, *step.get("arguments", []), **step.get("options", {}))
 
 
-def _insert_from_forward(step: dict[str, Any], data: dict[str, Any]) -> dict[str, Any]:
+def _insert_from_forward(step: dict[str, Any], fwd_data: dict[str, Any]) -> dict[str, Any]:
     # Inserting values for arguments
     arguments = step.get("arguments", [])
     for idx, argument in enumerate(arguments):
@@ -29,7 +29,7 @@ def _insert_from_forward(step: dict[str, Any], data: dict[str, Any]) -> dict[str
         if not needle:
             continue
         fwd_k = needle.group().replace("$", "")
-        arguments[idx] = data[fwd_k]
+        arguments[idx] = fwd_data[fwd_k]
     # Inserting values for options
     options = step.get("options", {})
     for key, option in options.items():
@@ -37,7 +37,7 @@ def _insert_from_forward(step: dict[str, Any], data: dict[str, Any]) -> dict[str
         if not needle:
             continue
         fwd_k = needle.group().replace("$", "")
-        options[key] = data[fwd_k]
+        options[key] = fwd_data[fwd_k]
     return {**step, "arguments": arguments, "options": options}
 
 
@@ -60,5 +60,3 @@ def run(ctx: click.Context, script: str):
         # Forwarding response data to next commands
         for fwd_k, data_k in step.get("forward", {}).items():
             forward_data[fwd_k] = jmespath.search(data_k, response.data)
-
-    logger.info(forward_data)

--- a/Babylon/commands/run.py
+++ b/Babylon/commands/run.py
@@ -1,0 +1,39 @@
+import logging
+import yaml
+from typing import Dict, Any
+import click
+from importlib import import_module
+
+from ..utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+def execute_step(root: click.Context, step: Dict[str, Any]):
+    logger.info(step.get("name"))
+    commands = step.get("command", "").split(" ")
+    to_import = "".join(
+            ["Babylon", "".join([f".groups.{group}" for group in commands[:-1]]), f".commands.{commands[-1]}"])
+    command_module = import_module(to_import, "Babylon")
+    cmd = getattr(command_module, commands[-1])
+    return root.invoke(cmd, **step.get("params", {}))
+
+
+@click.command
+@click.pass_context
+@click.argument("script", type=click.Path(readable=True, dir_okay=False))
+def run(ctx: click.Context, script: str):
+    """Run a macro script"""
+    with open(script, "r") as _f:
+        macro = yaml.safe_load(_f)
+    # Metadata
+    logger.info(f"Running {macro.get('name')}")
+    logger.info(macro.get("description"))
+    # Executing steps
+    root = ctx.find_root()
+    forward_data = {}
+    for step in macro.get("steps", []):
+        response: CommandResponse = execute_step(root, step)
+        for fwd_k, data_k in step.get("forward", {}).items():
+            forward_data[fwd_k] = response.data
+    logger.info(forward_data)

--- a/Babylon/commands/run.py
+++ b/Babylon/commands/run.py
@@ -13,7 +13,7 @@ def execute_step(root: click.Context, step: Dict[str, Any]):
     logger.info(step.get("name"))
     commands = step.get("command", "").split(" ")
     to_import = "".join(
-            ["Babylon", "".join([f".groups.{group}" for group in commands[:-1]]), f".commands.{commands[-1]}"])
+        ["Babylon", "".join([f".groups.{group}" for group in commands[:-1]]), f".commands.{commands[-1]}"])
     command_module = import_module(to_import, "Babylon")
     cmd = getattr(command_module, commands[-1])
     return root.invoke(cmd, **step.get("params", {}))

--- a/Babylon/groups/azure/__init__.py
+++ b/Babylon/groups/azure/__init__.py
@@ -1,34 +1,12 @@
-import logging
-import sys
-
-from azure.core.exceptions import ClientAuthenticationError
-from azure.identity import DefaultAzureCredential
 from click import group
-from click import pass_context
-from click.core import Context
 
-from ...utils.decorators import require_platform_key
-from ...utils.decorators import requires_external_program
 from .commands import list_commands
 from .groups import list_groups
 
-logger = logging.getLogger("Babylon")
-
 
 @group()
-@pass_context
-@requires_external_program("az")
-@require_platform_key("api_scope", "api_scope")
-def azure(ctx: Context, api_scope: str):
+def azure():
     """Group allowing communication with Microsoft Azure Cloud"""
-    creds = DefaultAzureCredential()
-    try:
-        # Authentication fails only when token can't be retrieved
-        creds.get_token(api_scope)
-        ctx.obj = creds
-    except ClientAuthenticationError:
-        logger.error("Please login to azure CLI with `az login`")
-        sys.exit(1)
 
 
 for _command in list_commands:

--- a/Babylon/groups/azure/connect.py
+++ b/Babylon/groups/azure/connect.py
@@ -1,0 +1,24 @@
+import logging
+from typing import Optional
+
+from azure.core.exceptions import ClientAuthenticationError
+from azure.identity import DefaultAzureCredential
+
+from ...utils.decorators import require_platform_key
+from ...utils.decorators import requires_external_program
+
+logger = logging.getLogger("Babylon")
+
+
+@requires_external_program("az")
+@require_platform_key("api_scope", "api_scope")
+def azure_connect(api_scope: Optional[str] = None):
+    """Group allowing communication with Microsoft Azure Cloud"""
+    creds = DefaultAzureCredential()
+    try:
+        # Authentication fails only when token can't be retrieved
+        creds.get_token(api_scope)
+        return creds
+    except ClientAuthenticationError as _e:
+        logger.error("Please login to azure CLI with `az login`")
+        raise _e

--- a/Babylon/groups/azure/groups/acr/commands/delete.py
+++ b/Babylon/groups/azure/groups/acr/commands/delete.py
@@ -1,13 +1,11 @@
 import logging
 import typing
 
-from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import ResourceNotFoundError
 from azure.core.exceptions import HttpResponseError
 from click import Choice
 from click import command
 from click import option
-from click import make_pass_decorator
 
 from ......utils.decorators import require_platform_key
 from ......utils.decorators import require_deployment_key
@@ -16,11 +14,8 @@ from ......utils.interactive import confirm_deletion
 
 logger = logging.getLogger("Babylon")
 
-pass_credentials = make_pass_decorator(DefaultAzureCredential)
-
 
 @command()
-@pass_credentials
 @require_platform_key("acr_src_registry_name", "acr_src_registry_name")
 @require_platform_key("acr_dest_registry_name", "acr_dest_registry_name")
 @require_deployment_key("simulator_repository", "simulator_repository")
@@ -35,8 +30,7 @@ pass_credentials = make_pass_decorator(DefaultAzureCredential)
     is_flag=True,
     help="Don't ask for validation before delete",
 )
-def delete(credentials: DefaultAzureCredential,
-           acr_src_registry_name: str,
+def delete(acr_src_registry_name: str,
            acr_dest_registry_name: str,
            simulator_repository: str,
            simulator_version: str,
@@ -49,7 +43,7 @@ def delete(credentials: DefaultAzureCredential,
     if not registry:
         logger.error("Please specify a registry to delete from with --direction or --registry")
         return
-    cr_client, _ = registry_connect(registry, credentials)
+    cr_client, _ = registry_connect(registry)
     image = image or f"{simulator_repository}:{simulator_version}"
     image = f"{image}:latest" if ":" not in image else image
     try:

--- a/Babylon/groups/azure/groups/acr/commands/list.py
+++ b/Babylon/groups/azure/groups/acr/commands/list.py
@@ -9,7 +9,6 @@ from click import option
 from ......utils.decorators import require_platform_key
 from ......utils.response import CommandResponse
 from ..registry_connect import registry_connect
-from ....connect import azure_connect
 
 logger = logging.getLogger("Babylon")
 
@@ -22,12 +21,11 @@ logger = logging.getLogger("Babylon")
 def list(acr_src_registry_name: str, acr_dest_registry_name: str, registry: typing.Optional[str],
          direction: typing.Optional[str]) -> CommandResponse:
     """List all docker images in the specified registry"""
-    credentials = azure_connect()
     registry = registry or {"src": acr_src_registry_name, "dest": acr_dest_registry_name}.get(direction)
     if not registry:
         logger.error("Please specify a registry to list from with --direction or --registry")
         return CommandResponse(status_code=CommandResponse.STATUS_ERROR)
-    cr_client, _ = registry_connect(registry, credentials)
+    cr_client, _ = registry_connect(registry)
     logger.info("Getting repositories stored in registry %s", registry)
     try:
         repos = [repo for repo in cr_client.list_repository_names()]

--- a/Babylon/groups/azure/groups/acr/commands/list.py
+++ b/Babylon/groups/azure/groups/acr/commands/list.py
@@ -1,31 +1,28 @@
 import logging
 import typing
 
-from azure.identity import DefaultAzureCredential
 from azure.core.exceptions import ServiceRequestError
 from click import Choice
 from click import command
 from click import option
-from click import make_pass_decorator
 
 from ......utils.decorators import require_platform_key
 from ......utils.response import CommandResponse
 from ..registry_connect import registry_connect
+from ....connect import azure_connect
 
 logger = logging.getLogger("Babylon")
 
-pass_credentials = make_pass_decorator(DefaultAzureCredential)
-
 
 @command()
-@pass_credentials
 @require_platform_key("acr_src_registry_name", "acr_src_registry_name")
 @require_platform_key("acr_dest_registry_name", "acr_dest_registry_name")
 @option("-r", "--registry", help="Container Registry name to scan, example: myregistry.azurecr.io")
 @option("-d", "--direction", type=Choice(["src", "dest"]), help="Container Registry choice to delete from")
-def list(credentials: DefaultAzureCredential, acr_src_registry_name: str, acr_dest_registry_name: str,
-         registry: typing.Optional[str], direction: typing.Optional[str]) -> CommandResponse:
+def list(acr_src_registry_name: str, acr_dest_registry_name: str, registry: typing.Optional[str],
+         direction: typing.Optional[str]) -> CommandResponse:
     """List all docker images in the specified registry"""
+    credentials = azure_connect()
     registry = registry or {"src": acr_src_registry_name, "dest": acr_dest_registry_name}.get(direction)
     if not registry:
         logger.error("Please specify a registry to list from with --direction or --registry")

--- a/Babylon/groups/azure/groups/acr/commands/pull.py
+++ b/Babylon/groups/azure/groups/acr/commands/pull.py
@@ -7,7 +7,6 @@ from click import option
 
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import require_platform_key
-from ....connect import azure_connect
 from ..registry_connect import registry_connect
 
 logger = logging.getLogger("Babylon")
@@ -27,8 +26,7 @@ def pull(acr_src_registry_name: str,
     """Pulls a docker image from the ACR registry given in platform configuration"""
     image = image or f"{simulator_repository}:{simulator_version}"
     registry = registry or acr_src_registry_name
-    credentials = azure_connect()
-    _, client = registry_connect(registry, credentials)
+    _, client = registry_connect(registry)
     repo = f"{registry}/{image}"
     logger.info(f"Pulling remote image {image} from registry {registry}")
     try:

--- a/Babylon/groups/azure/groups/acr/commands/pull.py
+++ b/Babylon/groups/azure/groups/acr/commands/pull.py
@@ -1,30 +1,25 @@
 import logging
 import typing
 
-from azure.identity import DefaultAzureCredential
 import docker
 from click import command
 from click import option
-from click import make_pass_decorator
 
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import require_platform_key
+from ....connect import azure_connect
 from ..registry_connect import registry_connect
 
 logger = logging.getLogger("Babylon")
 
-pass_credentials = make_pass_decorator(DefaultAzureCredential)
-
 
 @command()
-@pass_credentials
 @require_platform_key("acr_src_registry_name", "acr_src_registry_name")
 @require_deployment_key("simulator_repository", "simulator_repository")
 @require_deployment_key("simulator_version", "simulator_version")
 @option("-r", "--registry", help="Container Registry name to pull from, example: myregistry.azurecr.io")
 @option("-i", "--image", help="Remote docker image to pull, example hello-world:latest")
-def pull(credentials: DefaultAzureCredential,
-         acr_src_registry_name: str,
+def pull(acr_src_registry_name: str,
          simulator_repository: str,
          simulator_version: str,
          registry: typing.Optional[str] = None,
@@ -32,6 +27,7 @@ def pull(credentials: DefaultAzureCredential,
     """Pulls a docker image from the ACR registry given in platform configuration"""
     image = image or f"{simulator_repository}:{simulator_version}"
     registry = registry or acr_src_registry_name
+    credentials = azure_connect()
     _, client = registry_connect(registry, credentials)
     repo = f"{registry}/{image}"
     logger.info(f"Pulling remote image {image} from registry {registry}")

--- a/Babylon/groups/azure/groups/acr/commands/push.py
+++ b/Babylon/groups/azure/groups/acr/commands/push.py
@@ -2,9 +2,7 @@ import logging
 import typing
 
 import docker
-from azure.identity import DefaultAzureCredential
 from click import command
-from click import make_pass_decorator
 from click import option
 
 from ......utils.decorators import require_deployment_key
@@ -12,22 +10,20 @@ from ......utils.decorators import require_platform_key
 from ..registry_connect import registry_connect
 
 logger = logging.getLogger("Babylon")
-pass_credentials = make_pass_decorator(DefaultAzureCredential)
 
 
 @command()
-@pass_credentials
 @require_platform_key("acr_dest_registry_name", "acr_dest_registry_name")
 @require_deployment_key("simulator_repository", "simulator_repository")
 @require_deployment_key("simulator_version", "simulator_version")
 @option("-i", "--image", help="Local docker image to push")
 @option("-r", "--registry", help="Container Registry name to push to, example: myregistry.azurecr.io")
-def push(credentials: DefaultAzureCredential, acr_dest_registry_name: str, simulator_repository: str,
+def push(acr_dest_registry_name: str, simulator_repository: str,
          simulator_version: str, image: typing.Optional[str], registry: typing.Optional[str]):
     """Push a docker image to the ACR registry given in platform configuration"""
     registry: str = registry or acr_dest_registry_name
     image: str = image or f"{simulator_repository}:{simulator_version}"
-    _, client = registry_connect(registry, credentials)
+    _, client = registry_connect(registry)
     try:
         image_obj = client.images.get(image)
     except docker.errors.ImageNotFound:

--- a/Babylon/groups/azure/groups/acr/commands/push.py
+++ b/Babylon/groups/azure/groups/acr/commands/push.py
@@ -18,8 +18,8 @@ logger = logging.getLogger("Babylon")
 @require_deployment_key("simulator_version", "simulator_version")
 @option("-i", "--image", help="Local docker image to push")
 @option("-r", "--registry", help="Container Registry name to push to, example: myregistry.azurecr.io")
-def push(acr_dest_registry_name: str, simulator_repository: str,
-         simulator_version: str, image: typing.Optional[str], registry: typing.Optional[str]):
+def push(acr_dest_registry_name: str, simulator_repository: str, simulator_version: str, image: typing.Optional[str],
+         registry: typing.Optional[str]):
     """Push a docker image to the ACR registry given in platform configuration"""
     registry: str = registry or acr_dest_registry_name
     image: str = image or f"{simulator_repository}:{simulator_version}"

--- a/Babylon/groups/azure/groups/acr/registry_connect.py
+++ b/Babylon/groups/azure/groups/acr/registry_connect.py
@@ -3,15 +3,16 @@ import logging
 import subprocess
 
 from azure.containerregistry import ContainerRegistryClient
-from azure.identity import DefaultAzureCredential
 import docker
+
+from ...connect import azure_connect
 
 logger = logging.getLogger("Babylon")
 
 
-def registry_connect(registry: str,
-                     credentials: DefaultAzureCredential) -> tuple[ContainerRegistryClient, docker.DockerClient]:
+def registry_connect(registry: str) -> tuple[ContainerRegistryClient, docker.DockerClient]:
     # Login to registry
+    credentials = azure_connect()
     registry_client = ContainerRegistryClient(f"https://{registry}",
                                               credentials,
                                               audience="https://management.azure.com")

--- a/macros/macro_test.yaml
+++ b/macros/macro_test.yaml
@@ -3,11 +3,11 @@ description: This is a simple macro to demonstrate command chaining
 steps:
   - name: Getting list of container registries in source
     command: azure acr list
-    params:
+    options:
       direction: src
     forward:
       src_repos: repositories[0]
   - name: Getting list of container registry in destination
     command: azure acr pull
-    params:
+    options:
       image: $src_repos$

--- a/macros/macro_test.yaml
+++ b/macros/macro_test.yaml
@@ -6,11 +6,8 @@ steps:
     params:
       direction: src
     forward:
-      source_registries: data
-      other_val: data
+      src_repos: repositories[0]
   - name: Getting list of container registry in destination
-    command: azure acr list
+    command: azure acr pull
     params:
-      direction: dest
-    forward:
-      destination_registries: data
+      image: $src_repos$

--- a/macros/macro_test.yaml
+++ b/macros/macro_test.yaml
@@ -1,0 +1,16 @@
+name: Test macro
+description: This is a simple macro to demonstrate command chaining
+steps:
+  - name: Getting list of container registries in source
+    command: azure acr list
+    params:
+      direction: src
+    forward:
+      source_registries: data
+      other_val: data
+  - name: Getting list of container registry in destination
+    command: azure acr list
+    params:
+      direction: dest
+    forward:
+      destination_registries: data

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pyyaml
 docker
 terrasnek
 rich
+jmespath
 
 # Testing requirements
 pytest


### PR DESCRIPTION
## Usage:
```bash
babylon run macros/macro_test.yml
```

## Writing macros
Macros are yaml file with a predefined template, a macro will run a sequence of steps that are commands that can store and reuse results obtained by previous commands.
```yaml
name: Macro name 
description: Macro description
steps: # Steps to execute
```

### Step
A step is of the following form
```yaml
name: Test # The name of the step that will be printed during execution
command: The command to be run
arguments: # Argument to use in the command
  argument_value # This will insert the value as the first argument
  $forward_key$ # Arguments can use values stored as forward data
options: # Options to use in the command in the form key:value
   param_key: param_value # This is only used for options, this will add `--param_key param_value`
   other_key: $forward_key$ # This will use data that has been stored using the forward section
forward: # This will store command results in the forward data
  forward_key: query # This will store data from the command response, it can be filtered using JMESPath query
```

### Example macro
```yaml
name: Test macro
description: This is a simple macro to demonstrate command chaining
steps:
  - name: Getting list of container registries in source
    command: azure acr list
    options:
      direction: src
    forward:
      src_repos: repositories[0]
  - name: Getting list of container registry in destination
    command: azure acr pull
    options:
      image: $src_repos$
```