### PR TITLE
Add new custom type for parameters

### DIFF
--- a/Babylon/groups/api/groups/connector/commands/create.py
+++ b/Babylon/groups/api/groups/connector/commands/create.py
@@ -20,6 +20,7 @@ from ......utils.decorators import describe_dry_run
 from ......utils.decorators import pass_environment
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -54,7 +55,7 @@ pass_connector_api = make_pass_decorator(ConnectorApi)
         "use_working_dir_file",
         is_flag=True,
         help="Should the Connector file path be relative to Babylon working directory ?")
-@argument("connector-name")
+@argument("connector-name", type=QueryType())
 @option("-v", "--version", "connector_version", required=True, help="Version of the Connector")
 def create(
     env: Environment,

--- a/Babylon/groups/api/groups/connector/commands/delete.py
+++ b/Babylon/groups/api/groups/connector/commands/delete.py
@@ -10,6 +10,7 @@ from cosmotech_api.exceptions import ForbiddenException
 from cosmotech_api.exceptions import NotFoundException
 from cosmotech_api.exceptions import UnauthorizedException
 
+from ......utils.typing import QueryType
 from ......utils.api import get_api_file
 from ......utils.interactive import confirm_deletion
 from ......utils.decorators import describe_dry_run
@@ -27,6 +28,7 @@ pass_connector_api = make_pass_decorator(ConnectorApi)
 @argument(
     "connector_id",
     required=False,
+    type=QueryType(),
 )
 @option(
     "-i",

--- a/Babylon/groups/api/groups/connector/commands/get.py
+++ b/Babylon/groups/api/groups/connector/commands/get.py
@@ -17,6 +17,7 @@ from ......utils.api import filter_api_response_item
 from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -32,7 +33,7 @@ pass_connector_api = make_pass_decorator(ConnectorApi)
         "output_file",
         help="File to which content should be outputted (json-formatted)",
         type=Path())
-@argument("connector-id")
+@argument("connector-id", type=QueryType())
 @option("-f", "--fields", "fields", help="Fields witch will be keep in response data, by default all")
 def get(
     connector_api: ConnectorApi,

--- a/Babylon/groups/api/groups/dataset/commands/create.py
+++ b/Babylon/groups/api/groups/dataset/commands/create.py
@@ -22,6 +22,7 @@ from ......utils.decorators import pass_environment
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -33,7 +34,7 @@ pass_dataset_api = make_pass_decorator(DatasetApi)
 @timing_decorator
 @pass_dataset_api
 @pass_environment
-@argument("dataset_file", type=str, required=False)
+@argument("dataset_file", required=False, type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("connector", "connector")
 @option(

--- a/Babylon/groups/api/groups/dataset/commands/delete.py
+++ b/Babylon/groups/api/groups/dataset/commands/delete.py
@@ -16,6 +16,7 @@ from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.interactive import confirm_deletion
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -49,7 +50,7 @@ pass_dataset_api = make_pass_decorator(DatasetApi)
     help="In case the dataset id is retrieved from a file",
     required=False,
 )
-@argument("dataset_id", type=str, required=False)
+@argument("dataset_id", type=QueryType(), required=False)
 def delete(
     dataset_api: DatasetApi,
     organization_id: str,

--- a/Babylon/groups/api/groups/dataset/commands/get.py
+++ b/Babylon/groups/api/groups/dataset/commands/get.py
@@ -20,6 +20,7 @@ from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -30,7 +31,7 @@ pass_dataset_api = make_pass_decorator(DatasetApi)
 @describe_dry_run("Would call **dataset_api.find_dataset_by_id**")
 @pass_dataset_api
 @timing_decorator
-@argument("dataset_id")
+@argument("dataset_id", type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @option(
     "-o",

--- a/Babylon/groups/api/groups/dataset/commands/search.py
+++ b/Babylon/groups/api/groups/dataset/commands/search.py
@@ -17,6 +17,7 @@ from ......utils.api import filter_api_response
 from ......utils.api import get_api_file
 from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run, require_deployment_key, timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -27,7 +28,7 @@ pass_dataset_api = make_pass_decorator(DatasetApi)
 @describe_dry_run("Would call **dataset_api.search_datasets**")
 @pass_dataset_api
 @timing_decorator
-@argument("search_parameters", type=str)
+@argument("search_parameters", type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @option(
     "-o",

--- a/Babylon/groups/api/groups/dataset/commands/update.py
+++ b/Babylon/groups/api/groups/dataset/commands/update.py
@@ -16,6 +16,7 @@ from ......utils.api import get_api_file
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -26,7 +27,7 @@ pass_dataset_api = make_pass_decorator(DatasetApi)
 @describe_dry_run("Would call **dataset_api.update_dataset**")
 @pass_dataset_api
 @timing_decorator
-@argument("dataset_file")
+@argument("dataset_file", type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @require_deployment_key("dataset_id", "dataset_id")
 @option(

--- a/Babylon/groups/api/groups/organization/commands/create.py
+++ b/Babylon/groups/api/groups/organization/commands/create.py
@@ -19,6 +19,7 @@ from ......utils.decorators import describe_dry_run
 from ......utils.decorators import pass_environment
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -47,7 +48,7 @@ pass_organization_api = make_pass_decorator(OrganizationApi)
         "use_working_dir_file",
         is_flag=True,
         help="Should the Organization file path be relative to Babylon working directory ?")
-@argument("organization-name")
+@argument("organization-name", type=QueryType())
 def create(
     env: Environment,
     organization_api: OrganizationApi,

--- a/Babylon/groups/api/groups/organization/commands/delete.py
+++ b/Babylon/groups/api/groups/organization/commands/delete.py
@@ -14,6 +14,7 @@ from ......utils.api import get_api_file
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import timing_decorator
 from ......utils.interactive import confirm_deletion
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -27,6 +28,7 @@ pass_organization_api = make_pass_decorator(OrganizationApi)
 @argument(
     "organization_id",
     required=False,
+    type=QueryType(),
 )
 @option(
     "-i",

--- a/Babylon/groups/api/groups/organization/commands/get.py
+++ b/Babylon/groups/api/groups/organization/commands/get.py
@@ -17,6 +17,7 @@ from ......utils.api import filter_api_response_item
 from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -32,7 +33,7 @@ pass_organization_api = make_pass_decorator(OrganizationApi)
         "output_file",
         help="The path to the file where the new Organization content should be outputted (json-formatted)",
         type=Path())
-@argument("organization-id", type=str)
+@argument("organization-id", type=QueryType())
 @option(
     "-f",
     "--fields",

--- a/Babylon/groups/api/groups/solution/commands/create.py
+++ b/Babylon/groups/api/groups/solution/commands/create.py
@@ -21,6 +21,7 @@ from ......utils.decorators import pass_environment
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -32,7 +33,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @timing_decorator
 @pass_solution_api
 @pass_environment
-@argument("solution-name")
+@argument("solution-name", type=QueryType())
 @require_deployment_key("simulator_repository", "simulator_repository")
 @require_deployment_key("simulator_version", "simulator_version")
 @require_deployment_key("simulator_url", "simulator_url")

--- a/Babylon/groups/api/groups/solution/commands/delete.py
+++ b/Babylon/groups/api/groups/solution/commands/delete.py
@@ -16,6 +16,7 @@ from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.interactive import confirm_deletion
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -47,7 +48,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
     "solution_file",
     help="Your Solution description file path",
 )
-@argument("solution-id", required=False)
+@argument("solution-id", required=False, type=QueryType())
 def delete(
     solution_api: SolutionApi,
     organization_id: str,

--- a/Babylon/groups/api/groups/solution/commands/get.py
+++ b/Babylon/groups/api/groups/solution/commands/get.py
@@ -20,6 +20,7 @@ from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -30,7 +31,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @describe_dry_run("Would call **solution_api.find_solution_by_id** to get an solution details")
 @pass_solution_api
 @timing_decorator
-@argument("solution-id", required=False)
+@argument("solution-id", required=False, type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @option(
     "-o",

--- a/Babylon/groups/api/groups/solution/commands/update.py
+++ b/Babylon/groups/api/groups/solution/commands/update.py
@@ -16,6 +16,7 @@ from ......utils.api import get_api_file
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -26,7 +27,7 @@ pass_solution_api = make_pass_decorator(SolutionApi)
 @describe_dry_run("Would call **solution_api.create_solution** to update an solution")
 @timing_decorator
 @pass_solution_api
-@argument("solution-id", required=False)
+@argument("solution-id", required=False, type=QueryType())
 @require_deployment_key("simulator_url", "simulator_url")
 @require_deployment_key("simulator_version", "simulator_version")
 @require_deployment_key("simulator_repository", "simulator_repository")

--- a/Babylon/groups/api/groups/workspace/commands/create.py
+++ b/Babylon/groups/api/groups/workspace/commands/create.py
@@ -21,6 +21,7 @@ from ......utils.decorators import pass_environment
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
+from ......utils.typing import QueryType
 from cosmotech_api.exceptions import ServiceException
 
 logger = getLogger("Babylon")
@@ -33,7 +34,7 @@ pass_workspace_api = make_pass_decorator(WorkspaceApi)
 @timing_decorator
 @pass_workspace_api
 @pass_environment
-@argument("workspace-name")
+@argument("workspace-name", type=QueryType())
 @require_deployment_key("send_scenario_metadata_to_event_hub", "send_scenario_metadata_to_event_hub")
 @require_deployment_key("use_dedicated_event_hub_namespace", "use_dedicated_event_hub_namespace")
 @require_deployment_key("organization_id", "organization_id")

--- a/Babylon/groups/api/groups/workspace/commands/delete.py
+++ b/Babylon/groups/api/groups/workspace/commands/delete.py
@@ -18,6 +18,7 @@ from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.environment import Environment
 from ......utils.interactive import confirm_deletion
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -50,7 +51,7 @@ pass_workspace_api = make_pass_decorator(WorkspaceApi)
     "workspace_file",
     help="In case the workspace id is retrieved from a file",
 )
-@argument("workspace_id", required=False)
+@argument("workspace_id", required=False, type=QueryType())
 def delete(
     env: Environment,
     workspace_api: WorkspaceApi,

--- a/Babylon/groups/api/groups/workspace/commands/get.py
+++ b/Babylon/groups/api/groups/workspace/commands/get.py
@@ -20,6 +20,7 @@ from ......utils.api import underscore_to_camel
 from ......utils.decorators import describe_dry_run
 from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
+from ......utils.typing import QueryType
 
 logger = getLogger("Babylon")
 
@@ -30,7 +31,7 @@ pass_workspace_api = make_pass_decorator(WorkspaceApi)
 @describe_dry_run("Would call **workspace_api.find_workspace_by_id**")
 @pass_workspace_api
 @timing_decorator
-@argument("workspace-id", required=False)
+@argument("workspace-id", required=False, type=QueryType())
 @require_deployment_key("organization_id", "organization_id")
 @option(
     "-o",

--- a/Babylon/main.py
+++ b/Babylon/main.py
@@ -24,7 +24,7 @@ formatter = logging.Formatter('{message}', style='{', datefmt='%Y/%m/%d - %H:%M:
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
-env = initialize_environment(logger)
+env = initialize_environment()
 
 
 @click.group(name='babylon', context_settings=HELP_CONTEXT_OVERRIDE)

--- a/Babylon/utils/configuration.py
+++ b/Babylon/utils/configuration.py
@@ -290,6 +290,26 @@ class Configuration:
             return
         write_yaml_value(_path, var_name, var_value)
 
+    def get_deploy(self) -> Any:
+        """
+        Get deploy file after a yaml load
+        :return: result of yaml.safe_load for the deploy file
+        """
+        if not (_path := self.get_deploy_path()).exists():
+            return dict()
+        with _path.open("r") as _f:
+            return yaml.safe_load(_f)
+
+    def get_platform(self) -> Any:
+        """
+        Get platform file after a yaml load
+        :return: result of yaml.safe_load for the platform file
+        """
+        if not (_path := self.get_platform_path()).exists():
+            return dict()
+        with _path.open("r") as _f:
+            return yaml.safe_load(_f)
+
     def check_api(self) -> bool:
         """
         :return: True if the api targeted in the deploy is the same as the platform we use

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -1,3 +1,8 @@
+import os
+import pathlib
+
+import click
+
 from .configuration import Configuration
 from .working_dir import WorkingDir
 
@@ -8,3 +13,14 @@ class Environment:
         self.dry_run = False
         self.configuration = configuration
         self.working_dir = working_dir
+
+
+def initialize_environment(logger) -> Environment:
+    config_directory = pathlib.Path(os.environ.get('BABYLON_CONFIG_DIRECTORY', click.get_app_dir("babylon")))
+    conf = Configuration(config_directory=config_directory)
+
+    working_directory_path = pathlib.Path(os.environ.get('BABYLON_WORKING_DIRECTORY', "."))
+    work_dir = WorkingDir(working_dir_path=working_directory_path)
+
+    env = Environment(configuration=conf, working_dir=work_dir)
+    return env

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -15,7 +15,7 @@ class Environment:
         self.working_dir = working_dir
 
 
-def initialize_environment(logger) -> Environment:
+def initialize_environment() -> Environment:
     config_directory = pathlib.Path(os.environ.get('BABYLON_CONFIG_DIRECTORY', click.get_app_dir("babylon")))
     conf = Configuration(config_directory=config_directory)
 

--- a/Babylon/utils/help.py
+++ b/Babylon/utils/help.py
@@ -18,6 +18,10 @@ def print_cmd_help(ctx: click.Context, param: click.Parameter, value: str):
         click.echo(ctx.get_help())
         ctx.exit()
 
+    # In case no help is found in the parameters we should not go further
+    if not any(help_arg in args for help_arg in HELP_CONTEXT_OVERRIDE['help_option_names']):
+        return
+
     # create the command object manually and parse its arguments
     cmd = group
 

--- a/Babylon/utils/typing.py
+++ b/Babylon/utils/typing.py
@@ -1,0 +1,115 @@
+import logging
+import re
+from typing import Any
+from typing import List
+from typing import Optional
+
+import jmespath
+from click import Context
+from click import ParamType
+from click import Parameter
+from click.shell_completion import CompletionItem
+
+from .environment import initialize_environment
+
+logger = logging.getLogger("Babylon")
+env = initialize_environment(logger)
+
+WORKING_DIR_STRING = "workdir"
+DEPLOY_STRING = "deploy"
+PLATFORM_STRING = "platform"
+PATH_SYMBOL = "%"
+
+
+class QueryType(ParamType):
+    name = "filetype"
+
+    def shell_complete(self, ctx: "Context", param: "Parameter", incomplete: str) -> List["CompletionItem"]:
+        """
+        Allow auto-completion of the parameter
+        :param ctx: click context used to send this parameter value
+        :param param: name of the parameter to be completed
+        :param incomplete: actual value to complete
+        :return: a list of item that could be the completed version of the parameter
+        """
+        if not incomplete.startswith(PATH_SYMBOL):
+            return []
+
+        bases = [WORKING_DIR_STRING + '[]', DEPLOY_STRING, PLATFORM_STRING]
+        base_names = [f"{PATH_SYMBOL}{base}{PATH_SYMBOL}" for base in bases]
+
+        return [CompletionItem(_b) for _b in base_names if _b.startswith(incomplete)]
+
+    @staticmethod
+    def extract_value_content(value: Any) -> Optional[tuple[str, Optional[str], str]]:
+        """
+        Extract interesting information from a given value
+        :param value: Value of the parameter to extract
+        :return: None if value has no interesting info else element, filepath, and query
+        """
+
+        if not isinstance(value, str):
+            return None
+
+        check_regex = re.compile(f"{PATH_SYMBOL}"
+                                 f"({PLATFORM_STRING}|{DEPLOY_STRING}|{WORKING_DIR_STRING})"
+                                 f"(?:(?<={WORKING_DIR_STRING})\\[(.+)])?"
+                                 f"{PATH_SYMBOL}"
+                                 f"(.+)")
+
+        # Regex groups captures :
+        # 1 : Element to query : platform/deploy/workdir
+        # 2 : File path to query in case of a working dir
+        # 3 : jmespath query to apply
+
+        match_content = check_regex.match(value)
+        if not match_content:
+            return None
+        _type, _file, _query = match_content.groups()
+
+        return _type, _file, _query
+
+    def convert(self, value: Any, param: Optional["Parameter"], ctx: Optional["Context"]) -> Any:
+        """
+        Convert the value of the parameter given in the console to the one passed to the underlying function
+        :param value: the value sent by the console
+        :param param: the name of the parameter
+        :param ctx: the click context that lead to this call
+        :return: the value of the parameter that should be sent to the function
+        """
+
+        logger.debug(f"Converting '{value}' for parameter '{param.name}'")
+        conf = env.configuration
+
+        extracted_content = self.extract_value_content(value)
+        if not extracted_content:
+            logger.debug(f"  '{value}' -> no conversion applied")
+            return super().convert(value, param, ctx)
+
+        _type, _file, _query = extracted_content
+        # Check content of platform / deploy
+        possibles = {
+            DEPLOY_STRING: (conf.get_deploy(), conf.get_deploy_path()),
+            PLATFORM_STRING: (conf.get_platform(), conf.get_platform_path())
+        }
+
+        if _type in possibles:
+            logger.debug(f"    Detected parameter type '{_type}' with query '{_query}'")
+            _data, _path = possibles.get(_type)
+            r = jmespath.search(_query, _data)
+            if r is None:
+                self.fail(f"Could not find results for query '{_query}' in {_path}", param, ctx)
+        else:
+            # Check content of workdir
+            logger.debug(f"    Detected parameter type '{_type}' with query '{_query}' on file '{_file}'")
+            wd = env.working_dir
+            if not wd.requires_file(_file):
+                self.fail(f"File '{_file}' does not exists in current working dir.", param, ctx)
+
+            _content = wd.get_file_content(_file)
+            r = jmespath.search(_query, _content)
+            if r is None:
+                self.fail(f"Could not find results for query '{_query}' in '{wd.get_file(_file)}'", param, ctx)
+
+        logger.debug(f"   '{value}' -> '{r}'")
+        return r

--- a/Babylon/utils/typing.py
+++ b/Babylon/utils/typing.py
@@ -13,7 +13,7 @@ from click.shell_completion import CompletionItem
 from .environment import initialize_environment
 
 logger = logging.getLogger("Babylon")
-env = initialize_environment(logger)
+env = initialize_environment()
 
 WORKING_DIR_STRING = "workdir"
 DEPLOY_STRING = "deploy"

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -152,8 +152,7 @@ class WorkingDir:
                 return json.load(_f)
             elif _p.suffix == ".yaml":
                 return yaml.safe_load(_f)
-            else:
-                return list(_l for _l in _f)
+            return list(_l for _l in _f)
 
     def __str__(self):
         _ret = [

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -1,8 +1,10 @@
+import json
 import os
 import pathlib
 import shutil
 import zipfile
 import logging
+from typing import Any
 from typing import Optional
 
 import yaml
@@ -137,6 +139,21 @@ class WorkingDir:
         """
         target_file_path = self.path / pathlib.Path(file_path)
         return target_file_path
+
+    def get_file_content(self, file_path: str) -> Any:
+        """
+        Return the content of a file from the working dir
+        :param file_path: the path to the file inside the working dir
+        :return: a dump of the file content in python object
+        """
+        _p = self.get_file(file_path)
+        with open(_p) as _f:
+            if _p.suffix == ".json":
+                return json.load(_f)
+            elif _p.suffix == ".yaml":
+                return yaml.safe_load(_f)
+            else:
+                return list(_l for _l in _f)
 
     def __str__(self):
         _ret = [

--- a/docs/Utils/typing.md
+++ b/docs/Utils/typing.md
@@ -1,0 +1,12 @@
+::: Babylon.utils.typing.QueryType
+    handler: python
+    options:
+       show_root_heading: true
+       show_root_full_path: true
+       show_source: false
+       line_length: 40
+       docstring_style: sphinx
+       heading_level: 1
+       members:
+         - shell_complete
+         - convert

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
         - classes:
             - Configuration: 'Utils/config.md'
             - Working Directory: 'Utils/working_dir.md'
+        - typing: 'Utils/typing.md'
         - functions:
             - Decorators: 'Utils/decorators.md'
             - Cosmotech Api: 'Utils/api.md'

--- a/plugins/dev_tools/commands/__init__.py
+++ b/plugins/dev_tools/commands/__init__.py
@@ -1,3 +1,4 @@
+from .parameter_value import parameter_value
 from .initialize_command import initialize_command
 from .initialize_group import initialize_group
 from .initialize_plugin import initialize_plugin
@@ -6,6 +7,7 @@ from .move_group import move_group
 from .rename_command import rename_command
 
 list_commands = [
+    parameter_value,
     initialize_plugin,
     list_required_keys,
     move_group,

--- a/plugins/dev_tools/commands/parameter_value.py
+++ b/plugins/dev_tools/commands/parameter_value.py
@@ -1,0 +1,18 @@
+import logging
+
+from click import command
+from click import argument
+
+from rich.pretty import pretty_repr
+
+from Babylon.utils.typing import QueryType
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@argument('arg', type=QueryType())
+def parameter_value(arg):
+    """Will display the value of the given QueryType argument"""
+    logger.info("The value after conversion of the argument is:")
+    logger.info(pretty_repr(arg))

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ Cosmotech-Acceleration-Library
 
 # Other requirements
 pyyaml
+jmespath
 docker
 terrasnek
 rich

--- a/tests/utils/test_typing.py
+++ b/tests/utils/test_typing.py
@@ -1,0 +1,62 @@
+import random
+import string
+
+from Babylon.utils.typing import DEPLOY_STRING
+from Babylon.utils.typing import PATH_SYMBOL
+from Babylon.utils.typing import PLATFORM_STRING
+from Babylon.utils.typing import QueryType
+from Babylon.utils.typing import WORKING_DIR_STRING
+
+
+def gen_random_string(length=8):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+
+def test_extract_deploy():
+    random_text = gen_random_string(10)
+    composed_string = f"{PATH_SYMBOL}{DEPLOY_STRING}{PATH_SYMBOL}{random_text}"
+    _type, _path, _query = QueryType.extract_value_content(composed_string)
+    assert _type == DEPLOY_STRING
+    assert _path is None
+    assert _query == random_text
+
+
+def test_extract_platform():
+    random_text = gen_random_string(10)
+    composed_string = f"{PATH_SYMBOL}{PLATFORM_STRING}{PATH_SYMBOL}{random_text}"
+    _type, _path, _query = QueryType.extract_value_content(composed_string)
+    assert _type == PLATFORM_STRING
+    assert _path is None
+    assert _query == random_text
+
+
+def test_extract_working_dir():
+    random_text = gen_random_string(10)
+    random_text2 = gen_random_string(10)
+    composed_string = f"{PATH_SYMBOL}{WORKING_DIR_STRING}[{random_text2}]{PATH_SYMBOL}{random_text}"
+    _type, _path, _query = QueryType.extract_value_content(composed_string)
+    assert _type == WORKING_DIR_STRING
+    assert _path == random_text2
+    assert _query == random_text
+
+
+def test_extract_non_string():
+    assert QueryType.extract_value_content({'this is not a string'}) is None
+
+
+def test_extract_working_dir_wo_path():
+    random_text = gen_random_string(10)
+    assert QueryType.extract_value_content(f"{PATH_SYMBOL}{WORKING_DIR_STRING}[]{PATH_SYMBOL}{random_text}") is None
+
+
+def test_extract_working_dir_wo_query():
+    random_text = gen_random_string(10)
+    assert QueryType.extract_value_content(f"{PATH_SYMBOL}{WORKING_DIR_STRING}[{random_text}]{PATH_SYMBOL}") is None
+
+
+def test_extract_deploy_wo_query():
+    assert QueryType.extract_value_content(f"{PATH_SYMBOL}{DEPLOY_STRING}{PATH_SYMBOL}") is None
+
+
+def test_extract_platform_wo_query():
+    assert QueryType.extract_value_content(f"{PATH_SYMBOL}{PLATFORM_STRING}{PATH_SYMBOL}") is None


### PR DESCRIPTION
Description of the parameter type :
`QueryType` allow a syntax easiness to target file values from the configuration or the working directory :
Three type of queries can be written into parameters :
- `%deploy%Query`
- `%platform%Query`
- `%workdir[path/to/file]%Query`

The part between `%` allow to chose which file should be targeted, either the deploy or the platform files from the config or one precised file from the working dir. Then it is followed by a JMESPath query applied to the targeted file, the result of this query is then sent as a parameter value to the underlying function call. 

Calls to the `dry_run` mode will replace the given selector + query by the actual value that would be sent instead.