### PR TITLE
Overhaul update for terraform vars group

### DIFF
--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
@@ -14,6 +14,7 @@ from ........utils import TEMPLATE_FOLDER_PATH
 from ........utils.decorators import describe_dry_run
 from ........utils.decorators import timing_decorator
 from ........utils.decorators import working_dir_requires_yaml_key
+from ........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -22,20 +23,18 @@ pass_tfc = click.make_pass_decorator(TFC)
 
 @command()
 @pass_tfc
-@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use")
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
 @working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
 @describe_dry_run("Sending a variable creation payload to terraform")
-@argument("var_key")
-@argument("var_value")
-@argument("var_description")
+@argument("var_key", type=QueryType())
+@argument("var_value", type=QueryType())
+@argument("var_description", type=QueryType())
 @argument("var_category", type=click.Choice(['terraform', 'env'], case_sensitive=False), default='terraform')
 @option("--hcl", "var_hcl", is_flag=True, help="Should the var be evaluated as a HCL string")
 @option("--sensitive", "var_sensitive", is_flag=True, help="Is the var sensitive")
 @timing_decorator
-def create(
-    api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: str,
-    var_description: str, var_category: str, var_hcl: bool, var_sensitive: bool
-):
+def create(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: str,
+           var_description: str, var_category: str, var_hcl: bool, var_sensitive: bool):
     """Set VAR_KEY variable to VAR_VALUE in a workspace
 
 More information on the arguments can be found at :

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
@@ -28,7 +28,7 @@ pass_tfc = click.make_pass_decorator(TFC)
 @argument("var_key")
 @argument("var_value")
 @argument("var_description")
-@argument("var_category", type=click.Choice(['terraform', 'env'], case_sensitive=False))
+@argument("var_category", type=click.Choice(['terraform', 'env'], case_sensitive=False), default='terraform')
 @option("--hcl", "var_hcl", is_flag=True, help="Should the var be evaluated as a HCL string")
 @option("--sensitive", "var_sensitive", is_flag=True, help="Is the var sensitive")
 @timing_decorator

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/create.py
@@ -32,8 +32,10 @@ pass_tfc = click.make_pass_decorator(TFC)
 @option("--hcl", "var_hcl", is_flag=True, help="Should the var be evaluated as a HCL string")
 @option("--sensitive", "var_sensitive", is_flag=True, help="Is the var sensitive")
 @timing_decorator
-def create(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: str,
-           var_description: str, var_category: str, var_hcl: bool, var_sensitive: bool):
+def create(
+    api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: str,
+    var_description: str, var_category: str, var_hcl: bool, var_sensitive: bool
+):
     """Set VAR_KEY variable to VAR_VALUE in a workspace
 
 More information on the arguments can be found at :
@@ -52,10 +54,9 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
     var_payload['data']['attributes']['category'] = var_category
     var_payload['data']['attributes']['hcl'] = var_hcl
     var_payload['data']['attributes']['sensitive'] = var_sensitive
-    var_payload['data']['relationships']['workspace']['data']['id'] = workspace_id
 
     try:
-        r = api.vars.create(payload=var_payload)
+        r = api.workspace_vars.create(payload=var_payload)
     except TFCHTTPUnprocessableEntity as _error:
         logger.error(f"An issue appeared while processing variable {var_key} for workspace {workspace_id}:")
         logger.error(pprint.pformat(_error.args))

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/delete.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/delete.py
@@ -46,4 +46,4 @@ def delete(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key:
 
     logger.info(f"Deleting {var_key} from workspace {workspace_id}")
 
-    r = api.vars.destroy(variable_id=var_id)
+    r = api.workspace_vars.destroy(workspace_id=workspace_id, variable_id=var_id)

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/delete.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/delete.py
@@ -12,6 +12,7 @@ from ........utils.decorators import describe_dry_run
 from ........utils.decorators import timing_decorator
 from ........utils.decorators import working_dir_requires_yaml_key
 from ........utils.interactive import confirm_deletion
+from ........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -23,10 +24,10 @@ pass_tfc = click.make_pass_decorator(TFC)
 @describe_dry_run("""Would look up id for VAR_KEY in WORKSPACE_ID
 
 Then would send delete query to the API for it""")
-@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use")
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
 @option("-f", "--force", "force_validation", is_flag=True, help="Should validation be skipped ?")
 @working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
-@argument("var_key")
+@argument("var_key", type=QueryType())
 @timing_decorator
 def delete(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, force_validation: bool):
     """Delete VAR_KEY variable in a workspace"""

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/get.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/get.py
@@ -13,6 +13,7 @@ from terrasnek.api import TFC
 from ..list_all_vars import list_all_vars
 from ........utils.decorators import timing_decorator
 from ........utils.decorators import working_dir_requires_yaml_key
+from ........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -28,9 +29,9 @@ pass_tfc = click.make_pass_decorator(TFC)
     type=click.Path(file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path),
     help="File to which content should be outputted (json-formatted)",
 )
-@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use")
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
 @working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
-@argument("var_key")
+@argument("var_key", type=QueryType())
 @timing_decorator
 def get(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, output_file: Optional[pathlib.Path]):
     """Get VAR_KEY variable in a workspace"""

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/get_all.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/get_all.py
@@ -12,6 +12,7 @@ from terrasnek.api import TFC
 from ..list_all_vars import list_all_vars
 from ........utils.decorators import timing_decorator
 from ........utils.decorators import working_dir_requires_yaml_key
+from ........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -27,7 +28,7 @@ pass_tfc = click.make_pass_decorator(TFC)
     type=click.Path(file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path),
     help="File to which content should be outputted (json-formatted)",
 )
-@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use")
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
 @working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
 @timing_decorator
 def get_all(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], output_file: Optional[pathlib.Path]):

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/update.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/update.py
@@ -15,6 +15,7 @@ from ........utils import TEMPLATE_FOLDER_PATH
 from ........utils.decorators import describe_dry_run
 from ........utils.decorators import timing_decorator
 from ........utils.decorators import working_dir_requires_yaml_key
+from ........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -23,17 +24,15 @@ pass_tfc = click.make_pass_decorator(TFC)
 
 @command()
 @pass_tfc
-@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use")
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
 @working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
 @describe_dry_run("Would send a variable update payload to terraform")
-@argument("var_key")
-@option("--value", "var_value", help="A new value to apply to the variable")
-@option("--description", "var_description", help="A new description to apply to the variable")
+@argument("var_key", type=QueryType())
+@option("--value", "var_value", help="A new value to apply to the variable", type=QueryType())
+@option("--description", "var_description", help="A new description to apply to the variable", type=QueryType())
 @timing_decorator
-def update(
-    api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: Optional[str],
-    var_description: Optional[str]
-):
+def update(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: Optional[str],
+           var_description: Optional[str]):
     """Update VAR_KEY variable in a workspace
 
 More information on the arguments can be found at :

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/update.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/commands/update.py
@@ -30,8 +30,10 @@ pass_tfc = click.make_pass_decorator(TFC)
 @option("--value", "var_value", help="A new value to apply to the variable")
 @option("--description", "var_description", help="A new description to apply to the variable")
 @timing_decorator
-def update(api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: Optional[str],
-           var_description: Optional[str]):
+def update(
+    api: TFC, workspace_id_wd: str, workspace_id: Optional[str], var_key: str, var_value: Optional[str],
+    var_description: Optional[str]
+):
     """Update VAR_KEY variable in a workspace
 
 More information on the arguments can be found at :
@@ -59,7 +61,7 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
     var_payload['data']['attributes']['description'] = var_description or original_var['attributes']['description']
 
     try:
-        r = api.vars.update(variable_id=original_var['id'], payload=var_payload)
+        r = api.workspace_vars.update(variable_id=original_var['id'], payload=var_payload)
     except TFCHTTPUnprocessableEntity as _error:
         logger.error(f"An issue appeared while processing variable {var_key} for workspace {workspace_id}:")
         logger.error(pprint.pformat(_error.args))

--- a/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/list_all_vars.py
+++ b/Babylon/groups/terraform_cloud/groups/workspace/groups/vars/list_all_vars.py
@@ -17,12 +17,10 @@ def list_all_vars(api: TFC, workspace_id: str, lookup_var_sets: bool = True) -> 
     """
 
     try:
-        ws = api.workspaces.show(workspace_id=workspace_id)
+        ws_vars = api.workspace_vars.list(workspace_id=workspace_id)
     except TFCHTTPNotFound:
         logger.error(f"Workspace {workspace_id} does not exist in your terraform organization")
         return []
-    workspace_name = ws['data']['attributes']['name']
-    ws_vars = api.vars.list(workspace_name=workspace_name)
     r = []
 
     existing_keys = []

--- a/Babylon/templates/terraform_cloud/var_for_workspace_create.json
+++ b/Babylon/templates/terraform_cloud/var_for_workspace_create.json
@@ -8,14 +8,6 @@
       "category":null,
       "hcl":false,
       "sensitive":false
-    },
-    "relationships": {
-      "workspace": {
-        "data": {
-          "id":null,
-          "type":"workspaces"
-        }
-      }
     }
   }
 }

--- a/Babylon/utils/logging.py
+++ b/Babylon/utils/logging.py
@@ -14,5 +14,5 @@ class MultiLineHandler(rich.logging.RichHandler):
             return
         base_msg = record.msg[:]
         for line in base_msg.split("\n"):
-            record.msg = line
+            record.msg = line.rstrip()
             super().emit(record)


### PR DESCRIPTION
- `vars` api is marked as deprecated and will be soon removed so we replaced the calls to `workspace_vars` api
- Some calls were missing a default values so we added the more used one
- All parameters have received the `QueryType` allowing to lookup files for their content at call level