### PR TITLE
Eru/automate app registration

### DIFF
--- a/Babylon/groups/azure/groups/__init__.py
+++ b/Babylon/groups/azure/groups/__init__.py
@@ -1,3 +1,4 @@
+from .ad import ad
 from .staticwebapp import staticwebapp
 from .arm import arm
 from .acr import acr
@@ -8,6 +9,7 @@ from .appinsight import appinsight
 
 
 list_groups = [
+    ad,
     staticwebapp,
     arm,
     storage,

--- a/Babylon/groups/azure/groups/ad/__init__.py
+++ b/Babylon/groups/azure/groups/ad/__init__.py
@@ -1,3 +1,7 @@
+import sys
+
+from azure.identity import DefaultAzureCredential
+from azure.core.exceptions import ClientAuthenticationError
 from click import group
 from click import pass_context
 from click.core import Context
@@ -9,9 +13,14 @@ from .groups import list_groups
 @group()
 @pass_context
 def ad(ctx: Context):
-    """Group initialized from a template"""
-    pass
-
+    """Group interacting with Azure Active Directory"""
+    credentials = ctx.find_object(DefaultAzureCredential)
+    try:
+        token = credentials.get_token("https://graph.microsoft.com/.default")
+    except ClientAuthenticationError:
+        # Error message is handled by Azure API
+        sys.exit(0)
+    ctx.obj = token
 
 for _command in list_commands:
     ad.add_command(_command)

--- a/Babylon/groups/azure/groups/ad/__init__.py
+++ b/Babylon/groups/azure/groups/ad/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def ad(ctx: Context):
+    """Group initialized from a template"""
+    pass
+
+
+for _command in list_commands:
+    ad.add_command(_command)
+
+for _group in list_groups:
+    ad.add_command(_group)

--- a/Babylon/groups/azure/groups/ad/__init__.py
+++ b/Babylon/groups/azure/groups/ad/__init__.py
@@ -22,6 +22,7 @@ def ad(ctx: Context):
         sys.exit(0)
     ctx.obj = token
 
+
 for _command in list_commands:
     ad.add_command(_command)
 

--- a/Babylon/groups/azure/groups/ad/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/commands/__init__.py
@@ -1,0 +1,3 @@
+
+list_commands = [
+]

--- a/Babylon/groups/azure/groups/ad/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/__init__.py
@@ -1,5 +1,7 @@
+from .group import group
 from .app import app
 
 list_groups = [
+    group,
     app,
 ]

--- a/Babylon/groups/azure/groups/ad/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/__init__.py
@@ -1,0 +1,5 @@
+from .app import app
+
+list_groups = [
+    app,
+]

--- a/Babylon/groups/azure/groups/ad/groups/app/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/__init__.py
@@ -9,7 +9,7 @@ from .groups import list_groups
 @group()
 @pass_context
 def app(ctx: Context):
-    """Group initialized from a template"""
+    """Group interacting with Azure Active Directory Apps"""
     pass
 
 

--- a/Babylon/groups/azure/groups/ad/groups/app/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def app(ctx: Context):
+    """Group initialized from a template"""
+    pass
+
+
+for _command in list_commands:
+    app.add_command(_command)
+
+for _group in list_groups:
+    app.add_command(_group)

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
@@ -1,9 +1,11 @@
+from .update import update
 from .get_all import get_all
 from .get import get
 from .delete import delete
 from .create import create
 
 list_commands = [
+    update,
     get_all,
     get,
     delete,

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
@@ -1,0 +1,11 @@
+from .get_all import get_all
+from .get import get
+from .delete import delete
+from .create import create
+
+list_commands = [
+    get_all,
+    get,
+    delete,
+    create,
+]

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/__init__.py
@@ -1,3 +1,4 @@
+from .get_principal import get_principal
 from .update import update
 from .get_all import get_all
 from .get import get
@@ -5,6 +6,7 @@ from .delete import delete
 from .create import create
 
 list_commands = [
+    get_principal,
     update,
     get_all,
     get,

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
@@ -1,0 +1,57 @@
+import logging
+import pathlib
+from string import Template
+
+from azure.identity import DefaultAzureCredential
+from click import command
+from click import pass_context
+from click import Context
+from click import option
+from click import Path
+from rich.pretty import pretty_repr
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+from ........utils.environment import Environment
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@option("-f",
+        "--file",
+        "registration_file",
+        type=Path(readable=True, dir_okay=False, path_type=pathlib.Path),
+        required=True)
+@option("-e",
+        "--use-working-dir-file",
+        "use_working_dir_file",
+        is_flag=True,
+        help="Should the parameter file path be relative to Babylon working directory ?")
+def create(ctx: Context, registration_file: str, use_working_dir_file: bool = False) -> CommandResponse:
+    """
+    Register an app in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    """
+    credentials = ctx.find_object(DefaultAzureCredential)
+    access_token = credentials.get_token("https://graph.microsoft.com").token
+    route = "https://graph.microsoft.com/v1.0/applications"
+    env = Environment()
+    if use_working_dir_file:
+        registration_file = env.working_dir.get_file(str(registration_file))
+    details = ""
+    with open(registration_file, "r") as _file:
+        template = _file.read()
+        data = {**env.configuration.get_deploy(), **env.configuration.get_platform()}
+        try:
+            details = Template(template).substitute(data)
+        except Exception as e:
+            logger.error(f"Could not fill parameters template: {e}")
+            return CommandResponse.fail()
+    response = oauth_request(route, access_token, type="POST", data=details)
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success(output_data)

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 from string import Template
 
-from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AccessToken
 from click import command
 from click import pass_context
 from click import Context
@@ -32,10 +32,9 @@ logger = logging.getLogger("Babylon")
 def create(ctx: Context, registration_file: str, use_working_dir_file: bool = False) -> CommandResponse:
     """
     Register an app in active directory
-    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    https://learn.microsoft.com/en-us/graph/api/application-post-applications
     """
-    credentials = ctx.find_object(DefaultAzureCredential)
-    access_token = credentials.get_token("https://graph.microsoft.com").token
+    access_token = ctx.find_object(AccessToken).token
     route = "https://graph.microsoft.com/v1.0/applications"
     env = Environment()
     if use_working_dir_file:

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
@@ -13,6 +13,7 @@ from rich.pretty import pretty_repr
 from ........utils.request import oauth_request
 from ........utils.response import CommandResponse
 from ........utils.environment import Environment
+from ........utils.decorators import output_to_file
 
 logger = logging.getLogger("Babylon")
 
@@ -29,6 +30,7 @@ logger = logging.getLogger("Babylon")
         "use_working_dir_file",
         is_flag=True,
         help="Should the parameter file path be relative to Babylon working directory ?")
+@output_to_file
 def create(ctx: Context, registration_file: str, use_working_dir_file: bool = False) -> CommandResponse:
     """
     Register an app in active directory

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
@@ -16,20 +16,20 @@ logger = logging.getLogger("Babylon")
 
 @command()
 @pass_context
-@argument("application_id")
+@argument("registration_id")
 @option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
-def delete(ctx: Context, application_id: str, force_validation: bool = False) -> CommandResponse:
+def delete(ctx: Context, registration_id: str, force_validation: bool = False) -> CommandResponse:
     """
     Delete an app in active directory
     https://learn.microsoft.com/en-us/graph/api/application-delete
     """
-    if not force_validation and not confirm_deletion("registration", application_id):
+    if not force_validation and not confirm_deletion("registration", registration_id):
         return CommandResponse.fail()
     access_token = ctx.find_object(AccessToken).token
-    logger.info(f"Deleting app registration {application_id}")
-    route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
+    logger.info(f"Deleting app registration {registration_id}")
+    route = f"https://graph.microsoft.com/v1.0/applications/{registration_id}"
     response = oauth_request(route, access_token, type="DELETE")
     if response is None:
         return CommandResponse.fail()
-    logger.info(f"Successfully launched deletion of registration {application_id}")
+    logger.info(f"Successfully launched deletion of registration {registration_id}")
     return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
@@ -1,6 +1,6 @@
 import logging
 
-from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AccessToken
 from click import command
 from click import pass_context
 from click import Context
@@ -21,13 +21,12 @@ logger = logging.getLogger("Babylon")
 def delete(ctx: Context, application_id: str, force_validation: bool = False) -> CommandResponse:
     """
     Delete an app in active directory
-    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    https://learn.microsoft.com/en-us/graph/api/application-delete
     """
     if not force_validation and not confirm_deletion("registration", application_id):
         return CommandResponse.fail()
-    credentials = ctx.find_object(DefaultAzureCredential)
+    access_token = ctx.find_object(AccessToken).token
     logger.info(f"Deleting app registration {application_id}")
-    access_token = credentials.get_token("https://graph.microsoft.com").token
     route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
     response = oauth_request(route, access_token, type="DELETE")
     if response is None:

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/delete.py
@@ -1,0 +1,36 @@
+import logging
+
+from azure.identity import DefaultAzureCredential
+from click import command
+from click import pass_context
+from click import Context
+from click import option
+from click import argument
+
+from ........utils.interactive import confirm_deletion
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("application_id")
+@option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
+def delete(ctx: Context, application_id: str, force_validation: bool = False) -> CommandResponse:
+    """
+    Delete an app in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    """
+    if not force_validation and not confirm_deletion("registration", application_id):
+        return CommandResponse.fail()
+    credentials = ctx.find_object(DefaultAzureCredential)
+    logger.info(f"Deleting app registration {application_id}")
+    access_token = credentials.get_token("https://graph.microsoft.com").token
+    route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
+    response = oauth_request(route, access_token, type="DELETE")
+    if response is None:
+        return CommandResponse.fail()
+    logger.info(f"Successfully launched deletion of registration {application_id}")
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
@@ -1,0 +1,32 @@
+import logging
+
+from azure.identity import DefaultAzureCredential
+from click import command
+from click import pass_context
+from click import Context
+from click import argument
+from rich.pretty import pretty_repr
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("application_id")
+def get(ctx: Context, application_id: str) -> CommandResponse:
+    """
+    Get an app registration in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    """
+    credentials = ctx.find_object(DefaultAzureCredential)
+    access_token = credentials.get_token("https://graph.microsoft.com").token
+    route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
+    response = oauth_request(route, access_token)
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success(output_data)

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
@@ -1,6 +1,6 @@
 import logging
 
-from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AccessToken
 from click import command
 from click import pass_context
 from click import Context
@@ -19,10 +19,9 @@ logger = logging.getLogger("Babylon")
 def get(ctx: Context, application_id: str) -> CommandResponse:
     """
     Get an app registration in active directory
-    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    https://learn.microsoft.com/en-us/graph/api/application-get
     """
-    credentials = ctx.find_object(DefaultAzureCredential)
-    access_token = credentials.get_token("https://graph.microsoft.com").token
+    access_token = ctx.find_object(AccessToken).token
     route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
     response = oauth_request(route, access_token)
     if response is None:

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
@@ -15,14 +15,14 @@ logger = logging.getLogger("Babylon")
 
 @command()
 @pass_context
-@argument("application_id")
-def get(ctx: Context, application_id: str) -> CommandResponse:
+@argument("registration_id")
+def get(ctx: Context, registration_id: str) -> CommandResponse:
     """
     Get an app registration in active directory
     https://learn.microsoft.com/en-us/graph/api/application-get
     """
     access_token = ctx.find_object(AccessToken).token
-    route = f"https://graph.microsoft.com/v1.0/applications/{application_id}"
+    route = f"https://graph.microsoft.com/v1.0/applications/{registration_id}"
     response = oauth_request(route, access_token)
     if response is None:
         return CommandResponse.fail()

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get.py
@@ -9,6 +9,7 @@ from rich.pretty import pretty_repr
 
 from ........utils.request import oauth_request
 from ........utils.response import CommandResponse
+from ........utils.decorators import output_to_file
 
 logger = logging.getLogger("Babylon")
 
@@ -16,6 +17,7 @@ logger = logging.getLogger("Babylon")
 @command()
 @pass_context
 @argument("registration_id")
+@output_to_file
 def get(ctx: Context, registration_id: str) -> CommandResponse:
     """
     Get an app registration in active directory

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
@@ -1,0 +1,30 @@
+import logging
+
+from azure.identity import DefaultAzureCredential
+from click import command
+from click import pass_context
+from click import Context
+from rich.pretty import pretty_repr
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+def get_all(ctx: Context) -> CommandResponse:
+    """
+    Get all apps registered in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    """
+    credentials = ctx.find_object(DefaultAzureCredential)
+    access_token = credentials.get_token("https://graph.microsoft.com").token
+    route = "https://graph.microsoft.com/v1.0/applications"
+    response = oauth_request(route, access_token)
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success(output_data)

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
@@ -8,12 +8,14 @@ from rich.pretty import pretty_repr
 
 from ........utils.request import oauth_request
 from ........utils.response import CommandResponse
+from ........utils.decorators import output_to_file
 
 logger = logging.getLogger("Babylon")
 
 
 @command()
 @pass_context
+@output_to_file
 def get_all(ctx: Context) -> CommandResponse:
     """
     Get all apps registered in active directory

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get_all.py
@@ -1,6 +1,6 @@
 import logging
 
-from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AccessToken
 from click import command
 from click import pass_context
 from click import Context
@@ -17,10 +17,9 @@ logger = logging.getLogger("Babylon")
 def get_all(ctx: Context) -> CommandResponse:
     """
     Get all apps registered in active directory
-    https://learn.microsoft.com/en-us/graph/api/application-post-applications?view=graph-rest-1.0
+    https://learn.microsoft.com/en-us/graph/api/application-list
     """
-    credentials = ctx.find_object(DefaultAzureCredential)
-    access_token = credentials.get_token("https://graph.microsoft.com").token
+    access_token = ctx.find_object(AccessToken).token
     route = "https://graph.microsoft.com/v1.0/applications"
     response = oauth_request(route, access_token)
     if response is None:

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/get_principal.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/get_principal.py
@@ -1,0 +1,38 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import argument
+from rich.pretty import pretty_repr
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+from ........utils.decorators import output_to_file
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("registration_id")
+@output_to_file
+def get_principal(ctx: Context, registration_id: str) -> CommandResponse:
+    """
+    Get an app registration service principal in active directory
+    https://learn.microsoft.com/en-us/graph/api/serviceprincipal-get
+    """
+    access_token = ctx.find_object(AccessToken).token
+    get_route = f"https://graph.microsoft.com/v1.0/applications/{registration_id}"
+    get_response = oauth_request(get_route, access_token)
+    if get_response is None:
+        return CommandResponse.fail()
+    app_id = get_response.json().get("appId")
+    route = f"https://graph.microsoft.com/v1.0/servicePrincipals(appId='{app_id}')"
+    response = oauth_request(route, access_token)
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success(output_data)

--- a/Babylon/groups/azure/groups/ad/groups/app/commands/update.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/update.py
@@ -1,0 +1,59 @@
+import logging
+import pathlib
+from string import Template
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import option
+from click import argument
+from click import Path
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+from ........utils.environment import Environment
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("registration_id")
+@option("-f",
+        "--file",
+        "registration_file",
+        type=Path(readable=True, dir_okay=False, path_type=pathlib.Path),
+        required=True)
+@option("-e",
+        "--use-working-dir-file",
+        "use_working_dir_file",
+        is_flag=True,
+        help="Should the parameter file path be relative to Babylon working directory ?")
+def update(ctx: Context,
+           registration_id: str,
+           registration_file: str,
+           use_working_dir_file: bool = False) -> CommandResponse:
+    """
+    Update an app registration in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-update
+    """
+    access_token = ctx.find_object(AccessToken).token
+    route = f"https://graph.microsoft.com/v1.0/applications/{registration_id}"
+    env = Environment()
+    if use_working_dir_file:
+        registration_file = env.working_dir.get_file(str(registration_file))
+    details = ""
+    with open(registration_file, "r") as _file:
+        template = _file.read()
+        data = {**env.configuration.get_deploy(), **env.configuration.get_platform()}
+        try:
+            details = Template(template).substitute(data)
+        except Exception as e:
+            logger.error(f"Could not fill parameters template: {e}")
+            return CommandResponse.fail()
+    response = oauth_request(route, access_token, type="PATCH", data=details)
+    if response is None:
+        return CommandResponse.fail()
+    logger.info(f"Successfully updated registration {registration_id}")
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/__init__.py
@@ -1,3 +1,5 @@
+from .password import password
 
 list_groups = [
+    password,
 ]

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/password/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/password/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def password(ctx: Context):
+    """Group interactiving with app registration passwords and secrets"""
+    pass
+
+
+for _command in list_commands:
+    password.add_command(_command)
+
+for _group in list_groups:
+    password.add_command(_group)

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/__init__.py
@@ -1,0 +1,7 @@
+from .delete import delete
+from .create import create
+
+list_commands = [
+    delete,
+    create
+]

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/create.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/create.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Optional
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import option
+from click import argument
+from rich.pretty import pretty_repr
+
+from ..........utils.request import oauth_request
+from ..........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("app_id")
+@option("-n", "--name", "password_name", help="Password display name")
+def create(ctx: Context, app_id: str, password_name: Optional[str] = None) -> CommandResponse:
+    """
+    Register a password or secret to an app registration in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-addpassword
+    """
+    access_token = ctx.find_object(AccessToken).token
+    route = f"https://graph.microsoft.com/v1.0/applications/{app_id}/addPassword"
+    details = {"passwordCredential": {"displayName": password_name or f"secret_{app_id}"}}
+    response = oauth_request(route, access_token, type="POST", json=details)
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success(output_data)

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/delete.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/password/commands/delete.py
@@ -1,0 +1,36 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import option
+from click import argument
+
+from ..........utils.interactive import confirm_deletion
+from ..........utils.request import oauth_request
+from ..........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("app_id")
+@option("-k", "--key", "key_id", help="Password Key ID", required=True)
+@option("-f", "--force", "force_validation", is_flag=True, help="Don't ask for validation before delete")
+def delete(ctx: Context, app_id: str, key_id: str, force_validation: bool = False) -> CommandResponse:
+    """
+    Delete a password for an app registration in active directory
+    https://learn.microsoft.com/en-us/graph/api/application-delete
+    """
+    if not force_validation and not confirm_deletion("secret", key_id):
+        return CommandResponse.fail()
+    access_token = ctx.find_object(AccessToken).token
+    logger.info(f"Deleting secret {key_id} of app registration {app_id}")
+    route = f"https://graph.microsoft.com/v1.0/applications/{app_id}/removePassword"
+    response = oauth_request(route, access_token, type="POST", json={"keyId": key_id})
+    if response is None:
+        return CommandResponse.fail()
+    logger.info(f"Successfully deleted secret {key_id} of app registration {app_id}")
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/app/groups/password/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/groups/password/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/groups/azure/groups/ad/groups/group/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def group(ctx: Context):
+    """Group interacting with Azure Directory Groups"""
+    pass
+
+
+for _command in list_commands:
+    group.add_command(_command)
+
+for _group in list_groups:
+    group.add_command(_group)

--- a/Babylon/groups/azure/groups/ad/groups/group/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/commands/__init__.py
@@ -1,0 +1,5 @@
+from .get_all import get_all
+
+list_commands = [
+    get_all,
+]

--- a/Babylon/groups/azure/groups/ad/groups/group/commands/get_all.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/commands/get_all.py
@@ -1,0 +1,31 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from rich.pretty import pretty_repr
+
+from ........utils.request import oauth_request
+from ........utils.response import CommandResponse
+from ........utils.decorators import output_to_file
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@output_to_file
+def get_all(ctx: Context) -> CommandResponse:
+    """
+    Get all AD groups from current subscription
+    https://learn.microsoft.com/en-us/graph/api/group-list
+    """
+    access_token = ctx.find_object(AccessToken).token
+    route = "https://graph.microsoft.com/v1.0/groups/"
+    response = oauth_request(route, access_token, type="GET")
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/__init__.py
@@ -1,0 +1,5 @@
+from .member import member
+
+list_groups = [
+    member
+]

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/__init__.py
@@ -1,0 +1,20 @@
+from click import group
+from click import pass_context
+from click.core import Context
+
+from .commands import list_commands
+from .groups import list_groups
+
+
+@group()
+@pass_context
+def member(ctx: Context):
+    """Group interacting with Azure Directory Group members"""
+    pass
+
+
+for _command in list_commands:
+    member.add_command(_command)
+
+for _group in list_groups:
+    member.add_command(_group)

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/__init__.py
@@ -1,0 +1,9 @@
+from .remove import remove
+from .add import add
+from .get_all import get_all
+
+list_commands = [
+    remove,
+    add,
+    get_all,
+]

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/add.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/add.py
@@ -1,0 +1,31 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import argument
+
+from ..........utils.request import oauth_request
+from ..........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("group_id")
+@argument("service_principal_id")
+def add(ctx: Context, group_id: str, service_principal_id: str) -> CommandResponse:
+    """
+    Add a member in a group in active directory
+    https://learn.microsoft.com/en-us/graph/api/group-post-members
+    """
+    access_token = ctx.find_object(AccessToken).token
+    route = f"https://graph.microsoft.com/v1.0/groups/{group_id}/members/$ref"
+    details = {"@odata.id": f"https://graph.microsoft.com/v1.0/directoryObjects/{service_principal_id}"}
+    response = oauth_request(route, access_token, type="POST", json=details)
+    if response is None:
+        return CommandResponse.fail()
+    logger.info(f"Successfully added principal {service_principal_id} to group {group_id}")
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/get_all.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/get_all.py
@@ -1,0 +1,33 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import argument
+from rich.pretty import pretty_repr
+
+from ..........utils.request import oauth_request
+from ..........utils.response import CommandResponse
+from ..........utils.decorators import output_to_file
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("group_id")
+@output_to_file
+def get_all(ctx: Context, group_id: str) -> CommandResponse:
+    """
+    Get members of a group in active directory
+    https://learn.microsoft.com/en-us/graph/api/group-post-members
+    """
+    access_token = ctx.find_object(AccessToken).token
+    route = f"https://graph.microsoft.com/v1.0/groups/{group_id}/members/"
+    response = oauth_request(route, access_token, type="GET")
+    if response is None:
+        return CommandResponse.fail()
+    output_data = response.json()
+    logger.info(pretty_repr(output_data))
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/remove.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/remove.py
@@ -5,9 +5,11 @@ from click import command
 from click import pass_context
 from click import Context
 from click import argument
+from click import option
 
 from ..........utils.request import oauth_request
 from ..........utils.response import CommandResponse
+from ..........utils.interactive import confirm_deletion
 
 logger = logging.getLogger("Babylon")
 
@@ -16,10 +18,20 @@ logger = logging.getLogger("Babylon")
 @pass_context
 @argument("group_id")
 @argument("service_principal_id")
-def remove(ctx: Context, group_id: str, service_principal_id: str) -> CommandResponse:
+@option(
+    "-f",
+    "--force",
+    "force_validation",
+    is_flag=True,
+    help="Don't ask for validation before delete",
+)
+def remove(ctx: Context, group_id: str, service_principal_id: str, force_validation: bool = False) -> CommandResponse:
     """Remove a member from a group in active directory"""
+    if not force_validation and not confirm_deletion("member", service_principal_id):
+        return CommandResponse.fail()
     access_token = ctx.find_object(AccessToken).token
     route = f"https://graph.microsoft.com/v1.0/groups/{group_id}/members/{service_principal_id}/$ref"
+    logger.info(f"Deleting member {service_principal_id} from group {group_id}")
     response = oauth_request(route, access_token, type="DELETE")
     if response is None:
         return CommandResponse.fail()

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/remove.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/remove.py
@@ -1,0 +1,27 @@
+import logging
+
+from azure.core.credentials import AccessToken
+from click import command
+from click import pass_context
+from click import Context
+from click import argument
+
+from ..........utils.request import oauth_request
+from ..........utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_context
+@argument("group_id")
+@argument("service_principal_id")
+def remove(ctx: Context, group_id: str, service_principal_id: str) -> CommandResponse:
+    """Remove a member from a group in active directory"""
+    access_token = ctx.find_object(AccessToken).token
+    route = f"https://graph.microsoft.com/v1.0/groups/{group_id}/members/{service_principal_id}/$ref"
+    response = oauth_request(route, access_token, type="DELETE")
+    if response is None:
+        return CommandResponse.fail()
+    logger.info(f"Successfully removed principal {service_principal_id} from group {group_id}")
+    return CommandResponse.success()

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/groups/__init__.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/groups/__init__.py
@@ -1,0 +1,3 @@
+
+list_groups = [
+]

--- a/Babylon/templates/working_dir_template/app_registration.json
+++ b/Babylon/templates/working_dir_template/app_registration.json
@@ -1,0 +1,9 @@
+{
+    "displayName": "babylon_test",
+    "signInAudience": "AzureADMyOrg",
+    "spa": {
+        "redirectUris": [
+            "https://DOMAIN_NAME_PREFIX.app.cosmotech.com/scenario"
+        ]
+    }
+}

--- a/Babylon/templates/working_dir_template/app_registration.json
+++ b/Babylon/templates/working_dir_template/app_registration.json
@@ -1,9 +1,20 @@
 {
-    "displayName": "babylon_test",
+    "displayName": "my_app_registration",
     "signInAudience": "AzureADMyOrg",
     "spa": {
         "redirectUris": [
             "https://DOMAIN_NAME_PREFIX.app.cosmotech.com/scenario"
         ]
-    }
+    },
+    "requiredResourceAccess": [
+        {
+            "resourceAppId": "<phoenix code dev id>",
+            "resourceAccess": [
+                {
+                    "id": "<cosmotech platform id>",
+                    "type": "Scope"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
Added Babylon commands that allow creating app registrations

```bash
babylon azure ad app create -e -f app_registration.json
babylon azure ad app get [registration_id]
babylon azure ad app update [registration_id] -e -f app_registration.json
babylon azure ad app delete -f [registration_id]
babylon azure ad app password create [registration_id] -n my_password
babylon azure ad app password delete [registration_id] -k [key_id]
babylon azure ad group member get-all [group_id]
babylon azure ad group member add [group_id] [registration_id]
babylon azure ad group member remove [group_id] [registration_id]
```