### PR TITLE
Macro command - PowerBI workspace deployment

### DIFF
--- a/Babylon/groups/powerbi/commands/__init__.py
+++ b/Babylon/groups/powerbi/commands/__init__.py
@@ -1,3 +1,5 @@
+from .deploy_workspace import deploy_workspace
 
 list_commands = [
+    deploy_workspace,
 ]

--- a/Babylon/groups/powerbi/commands/deploy_workspace.py
+++ b/Babylon/groups/powerbi/commands/deploy_workspace.py
@@ -21,8 +21,14 @@ logger = logging.getLogger("Babylon")
         "-f",
         "report_folder",
         type=Path(exists=True, dir_okay=True, file_okay=False, readable=True, path_type=pathlib.Path),
-        default="./powerbi-reports")
-@option("--report-parameter", "-p", "report_parameters", type=(QueryType(), QueryType()), multiple=True)
+        default="./powerbi-reports",
+        help="Override folder containing your .pbix files")
+@option("--report-parameter",
+        "-p",
+        "report_parameters",
+        type=(QueryType(), QueryType()),
+        multiple=True,
+        help="Add a combination <Key Value> that will be sent as parameter to all your datasets")
 def deploy_workspace(workspace_name: str, report_folder: pathlib.Path, report_parameters: Iterable[Tuple[str, str]]):
     """Macro command allowing full deployment of a power bi workspace
 

--- a/Babylon/groups/powerbi/commands/deploy_workspace.py
+++ b/Babylon/groups/powerbi/commands/deploy_workspace.py
@@ -1,0 +1,67 @@
+import logging
+import pathlib
+from typing import Iterable
+from typing import Tuple
+
+from click import Path
+from click import argument
+from click import command
+from click import option
+
+from ....utils.command_helper import run_command
+from ....utils.response import CommandResponse
+from ....utils.typing import QueryType
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@argument("workspace_name", type=QueryType())
+@option("--report-folder",
+        "-f",
+        "report_folder",
+        type=Path(exists=True, dir_okay=True, file_okay=False, readable=True, path_type=pathlib.Path),
+        default="./powerbi-reports")
+@option("--report-parameter", "-p", "report_parameters", type=(QueryType(), QueryType()), multiple=True)
+def deploy_workspace(workspace_name: str, report_folder: pathlib.Path, report_parameters: Iterable[Tuple[str, str]]):
+    """Macro command allowing full deployment of a power bi workspace
+
+    Require a local folder named `powerbi-reports` and will initialize a full workspace with the given reports"""
+    r_create_ws: CommandResponse = run_command(f"powerbi workspace create -s {workspace_name}".split())
+    if r_create_ws.status_code == r_create_ws.STATUS_ERROR:
+        logger.error("Error while creating the workspace")
+        return
+    workspace_id = r_create_ws.data['id']
+    logger.info(f"Created workspace {workspace_name} - {workspace_id}")
+    logger.info("Uploading reports")
+    for report_path in report_folder.glob("*.pbix"):
+        logger.info("")
+        logger.info(f"Uploading \"{report_path}\"")
+        r_upload_report: CommandResponse = run_command(f"powerbi report upload -w {workspace_id}".split() +
+                                                       [str(report_path)])
+        if r_upload_report.status_code == r_create_ws.STATUS_ERROR:
+            logger.error(f"Error while updating the report \"{report_path}\"")
+            continue
+        reports = r_upload_report.data.get('reports', [])
+        for report in reports:
+            logger.info(f"Uploaded report \"{report.get('name')}\" ({report.get('id')})")
+        datasets = r_upload_report.data.get('datasets', [])
+        for dataset in datasets:
+            dataset_id = dataset.get('id')
+            if report_parameters:
+                logger.info(f"Applying parameters to dataset \"{dataset.get('name')}\" ({dataset_id})")
+                for k, v in report_parameters:
+                    r_update_parameter: CommandResponse = run_command(
+                        f"powerbi dataset parameters update {dataset_id} -w {workspace_id} -p {k} {v}".split())
+                    if r_update_parameter.status_code == r_create_ws.STATUS_ERROR:
+                        logger.error(f"Error while setting the parameter {k}")
+                        continue
+            else:
+                logger.warning("No parameter to apply")
+            logger.info(f"Updating credentials for dataset \"{dataset.get('name')}\" ({dataset_id})")
+            r_update_credentials: CommandResponse = run_command(
+                f"powerbi dataset update-credentials {dataset_id} -w {workspace_id}".split())
+            if r_update_credentials.status_code == r_create_ws.STATUS_ERROR:
+                logger.error(f"Error while updating credentials for dataset  \"{dataset.get('name')}\" ({dataset_id})")
+                continue
+    logger.info(f"DONE - Workspace deployment of \"{workspace_name}\" ({workspace_id})")

--- a/Babylon/utils/api.py
+++ b/Babylon/utils/api.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 from typing import Iterable
 
-import click
 import yaml
 
 from .environment import Environment
@@ -96,7 +95,7 @@ def get_api_file(api_file_path: str, use_working_dir_file: bool):
     """
     _file_path = pathlib.Path(api_file_path)
     if use_working_dir_file:
-        _file_path = click.get_current_context().find_object(Environment).working_dir.get_file(api_file_path)
+        _file_path = Environment().working_dir.get_file(api_file_path)
     if not _file_path.exists():
         logger.error(f"{_file_path} does not exists.")
         return None

--- a/Babylon/utils/command_helper.py
+++ b/Babylon/utils/command_helper.py
@@ -1,17 +1,26 @@
-import click
+import logging
 from typing import Any
 
+import click
 
-def run_command(command_line: list[str]) -> Any:
+logger = logging.getLogger("Babylon")
+
+
+def run_command(command_line: list[str], log_level=logging.WARNING) -> Any:
     """
     Helper used to run a command
     :param command_line: command line of the command to run
     :return: result of the command
     """
+    logger.debug(f"Running command: {' '.join(command_line)}")
+    old_log_level = logger.level
+    if old_log_level < log_level:
+        logger.setLevel(log_level)
     root = click.get_current_context().find_root()
     babylon = root.command
     ctx = click.Context(babylon, parent=root)
     name, cmd, args = babylon.resolve_command(ctx, command_line)
     cmd.parse_args(ctx, args)
     ret = cmd.invoke(ctx)
+    logger.setLevel(old_log_level)
     return ret

--- a/Babylon/utils/decorators.py
+++ b/Babylon/utils/decorators.py
@@ -102,10 +102,7 @@ def working_dir_requires_yaml_key(yaml_path: str, yaml_key: str, arg_name: Optio
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any):
-            env = click.get_current_context().find_object(Environment)
-            if not env:
-                logger.error("Could not find environment in click context")
-                raise ValueError("Could not find environment in click context")
+            env = Environment()
             working_dir = env.working_dir
             if working_dir.requires_yaml_key(yaml_path=yaml_path, yaml_key=yaml_key):
                 if arg_name:
@@ -136,10 +133,7 @@ def working_dir_requires_file(file_path: str, arg_name: Optional[str] = None) ->
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any):
-            env = click.get_current_context().find_object(Environment)
-            if not env:
-                logger.error("Could not find environment in click context")
-                raise ValueError("Could not find environment in click context")
+            env = Environment()
             working_dir = env.working_dir
             if working_dir.requires_file(file_path=file_path):
                 if arg_name:
@@ -222,20 +216,12 @@ def insert_argument(getter: Callable[[str], Any]) -> Callable[..., Any]:
 
 def get_from_deploy_config(yaml_key: str) -> Optional[Any]:
     """deploy config file"""
-    env = click.get_current_context().find_object(Environment)
-    if not env:
-        logger.error("Could not find environment in click context")
-        raise ValueError("Could not find environment in click context")
-    return env.configuration.get_deploy_var(yaml_key)
+    return Environment().configuration.get_deploy_var(yaml_key)
 
 
 def get_from_platform_config(yaml_key: str) -> Optional[Any]:
     """platform config file"""
-    env = click.get_current_context().find_object(Environment)
-    if not env:
-        logger.error("Could not find environment in click context")
-        raise ValueError("Could not find environment in click context")
-    return env.configuration.get_platform_var(yaml_key)
+    return Environment().configuration.get_platform_var(yaml_key)
 
 
 require_deployment_key = insert_argument(get_from_deploy_config)

--- a/Babylon/utils/typing.py
+++ b/Babylon/utils/typing.py
@@ -16,7 +16,7 @@ env = Environment()
 
 
 class QueryType(ParamType):
-    name = "filetype"
+    name = "QueryString"
 
     def shell_complete(self, ctx: "Context", param: "Parameter", incomplete: str) -> List["CompletionItem"]:
         """

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Babylon
 
+[![End-User-Documentation](https://img.shields.io/badge/End_User_Documentation-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://cosmo-tech.github.io/Babylon-End-User-Doc/)
 [![Documentation](https://img.shields.io/badge/Documentation-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://cosmo-tech.github.io/Babylon/)
 [![Cosmotech](https://img.shields.io/badge/Cosmotech-ffb039?style=for-the-badge&logoColor=black)](https://cosmotech.com/)
 


### PR DESCRIPTION
Added new macro command : `powerbi deploy-workspace`
- Takes 1 argument : `WORKSPACE_NAME` a unique name for the workspace
- Takes 2 options :
    - `--report-folder` : allow to indicate which folder containing `.pbix` files to use for the initial deployment
    - `--report-parameter` : allow to define a parameter by the combination `KEY VALUE` that will be applied to all the datasets deployed
Added a `log_level` parameter to the `run_command` helper allowing to set the log level of the command.
