### PR TITLE
Added Macro Method chaining

### DIFF
--- a/Babylon/groups/api/groups/organization/commands/get_all.py
+++ b/Babylon/groups/api/groups/organization/commands/get_all.py
@@ -55,15 +55,16 @@ def get_all(
     logger.debug(pformat(retrieved_organizations))
     if fields:
         retrieved_organizations = filter_api_response(retrieved_organizations, fields.replace(" ", "").split(","))
+    _organizations_to_dump = [convert_keys_case(_ele, underscore_to_camel) for _ele in retrieved_organizations]
+    data = [_ele.to_dict() for _ele in _organizations_to_dump]
     if not output_file:
         logger.info(pformat(retrieved_organizations))
-        return CommandResponse.success({"organizations": retrieved_organizations})
+        return CommandResponse.success({"organizations": data})
 
-    _organizations_to_dump = [convert_keys_case(_ele, underscore_to_camel) for _ele in retrieved_organizations]
     with open(output_file, "w") as _file:
         try:
-            json.dump([_ele.to_dict() for _ele in _organizations_to_dump], _file, ensure_ascii=False)
+            json.dump(data, _file, ensure_ascii=False)
         except AttributeError:
             json.dump(_organizations_to_dump, _file, ensure_ascii=False)
     logger.info(f"Full content was dumped on {output_file}")
-    return CommandResponse.success({"organizations": retrieved_organizations})
+    return CommandResponse.success({"organizations": data})

--- a/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/add.py
+++ b/Babylon/groups/azure/groups/ad/groups/group/groups/member/commands/add.py
@@ -8,14 +8,15 @@ from click import argument
 
 from ..........utils.request import oauth_request
 from ..........utils.response import CommandResponse
+from ..........utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
 
 @command()
 @pass_context
-@argument("group_id")
-@argument("service_principal_id")
+@argument("group_id", type=QueryType())
+@argument("service_principal_id", type=QueryType())
 def add(ctx: Context, group_id: str, service_principal_id: str) -> CommandResponse:
     """
     Add a member in a group in active directory

--- a/Babylon/groups/config/groups/deployment/commands/set_variable.py
+++ b/Babylon/groups/config/groups/deployment/commands/set_variable.py
@@ -5,13 +5,14 @@ from click import argument
 
 from ......utils.environment import Environment
 from ......utils.response import CommandResponse
+from ......utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
 
 @command()
-@argument("variable_key")
-@argument("variable_value")
+@argument("variable_key", type=QueryType())
+@argument("variable_value", type=QueryType())
 def set_variable(variable_key: str, variable_value: str):
     """Set a deployment variable with a new value"""
     env = Environment()

--- a/Babylon/groups/powerbi/commands/deploy_workspace.py
+++ b/Babylon/groups/powerbi/commands/deploy_workspace.py
@@ -8,9 +8,8 @@ from click import argument
 from click import command
 from click import option
 
-from ....utils.command_helper import run_command
-from ....utils.response import CommandResponse
 from ....utils.typing import QueryType
+from ....utils.macro import Macro
 
 logger = logging.getLogger("Babylon")
 
@@ -33,41 +32,36 @@ def deploy_workspace(workspace_name: str, report_folder: pathlib.Path, report_pa
     """Macro command allowing full deployment of a power bi workspace
 
     Require a local folder named `powerbi-reports` and will initialize a full workspace with the given reports"""
-    r_create_ws: CommandResponse = run_command(f"powerbi workspace create -s {workspace_name}".split())
-    if r_create_ws.status_code == r_create_ws.STATUS_ERROR:
-        logger.error("Error while creating the workspace")
-        return
-    workspace_id = r_create_ws.data['id']
-    logger.info(f"Created workspace {workspace_name} - {workspace_id}")
-    logger.info("Uploading reports")
-    for report_path in report_folder.glob("*.pbix"):
-        logger.info("")
-        logger.info(f"Uploading \"{report_path}\"")
-        r_upload_report: CommandResponse = run_command(f"powerbi report upload -w {workspace_id}".split() +
-                                                       [str(report_path)])
-        if r_upload_report.status_code == r_create_ws.STATUS_ERROR:
-            logger.error(f"Error while updating the report \"{report_path}\"")
-            continue
-        reports = r_upload_report.data.get('reports', [])
-        for report in reports:
-            logger.info(f"Uploaded report \"{report.get('name')}\" ({report.get('id')})")
-        datasets = r_upload_report.data.get('datasets', [])
-        for dataset in datasets:
-            dataset_id = dataset.get('id')
-            if report_parameters:
-                logger.info(f"Applying parameters to dataset \"{dataset.get('name')}\" ({dataset_id})")
-                for k, v in report_parameters:
-                    r_update_parameter: CommandResponse = run_command(
-                        f"powerbi dataset parameters update {dataset_id} -w {workspace_id} -p {k} {v}".split())
-                    if r_update_parameter.status_code == r_create_ws.STATUS_ERROR:
-                        logger.error(f"Error while setting the parameter {k}")
-                        continue
-            else:
-                logger.warning("No parameter to apply")
-            logger.info(f"Updating credentials for dataset \"{dataset.get('name')}\" ({dataset_id})")
-            r_update_credentials: CommandResponse = run_command(
-                f"powerbi dataset update-credentials {dataset_id} -w {workspace_id}".split())
-            if r_update_credentials.status_code == r_create_ws.STATUS_ERROR:
-                logger.error(f"Error while updating credentials for dataset  \"{dataset.get('name')}\" ({dataset_id})")
-                continue
-    logger.info(f"DONE - Workspace deployment of \"{workspace_name}\" ({workspace_id})")
+    report_params = " ".join([f"-p {param[0]} {param[1]}" for param in report_parameters])
+    Macro("powerbi workspace deploy") \
+        .step(["powerbi", "workspace", "create", "-s", workspace_name], store_at="workspace") \
+        .step(
+            ["powerbi", "report", "upload", "-w", "%datastore%workspace.data.id", report_folder], store_at="reports") \
+        .iterate(["powerbi", "dataset", "parameters", "update", "-w", "%datastore%workspace.data.id", report_params],
+                 iterate_on="%datastore%reports.data.datasets") \
+        .dump("powerbi_deploy_workspace.json")
+
+    # for report_path in report_folder.glob("*.pbix"):
+    #     reports = r_upload_report.data.get('reports', [])
+    #     for report in reports:
+    #         logger.info(f"Uploaded report \"{report.get('name')}\" ({report.get('id')})")
+    #     datasets = r_upload_report.data.get('datasets', [])
+    #     for dataset in datasets:
+    #         dataset_id = dataset.get('id')
+    #         if report_parameters:
+    #             logger.info(f"Applying parameters to dataset \"{dataset.get('name')}\" ({dataset_id})")
+    #             for k, v in report_parameters:
+    #                 r_update_parameter: CommandResponse = run_command(
+    #                     f"powerbi dataset parameters update {dataset_id} -w {workspace_id} -p {k} {v}".split())
+    #                 if r_update_parameter.status_code == r_create_ws.STATUS_ERROR:
+    #                     logger.error(f"Error while setting the parameter {k}")
+    #                     continue
+    #         else:
+    #             logger.warning("No parameter to apply")
+    #         logger.info(f"Updating credentials for dataset \"{dataset.get('name')}\" ({dataset_id})")
+    #         r_update_credentials: CommandResponse = run_command(
+    #             f"powerbi dataset update-credentials {dataset_id} -w {workspace_id}".split())
+    #         if r_update_credentials.status_code == r_create_ws.STATUS_ERROR:
+    #             logger.error(f"Error while updating credentials for dataset  \"{dataset.get('name')}\" ({dataset_id})")
+    #             continue
+    # logger.info(f"DONE - Workspace deployment of \"{workspace_name}\" ({workspace_id})")

--- a/Babylon/groups/powerbi/groups/dataset/commands/take_over.py
+++ b/Babylon/groups/powerbi/groups/dataset/commands/take_over.py
@@ -11,6 +11,7 @@ from click import option
 from ......utils.decorators import require_deployment_key
 from ......utils.response import CommandResponse
 from ......utils.request import oauth_request
+from ......utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -19,7 +20,7 @@ logger = logging.getLogger("Babylon")
 @pass_context
 @require_deployment_key("powerbi_workspace_id", required=False)
 @argument("dataset_id")
-@option("-w", "--workspace", "workspace_id", help="PowerBI workspace ID")
+@option("-w", "--workspace", "workspace_id", type=QueryType(), help="PowerBI workspace ID")
 def take_over(ctx: Context,
               powerbi_workspace_id: str,
               dataset_id: str,

--- a/Babylon/groups/powerbi/groups/dataset/commands/update_credentials.py
+++ b/Babylon/groups/powerbi/groups/dataset/commands/update_credentials.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("Babylon")
 @pass_context
 @require_deployment_key("powerbi_workspace_id", required=False)
 @argument("dataset_id", type=QueryType())
-@option("-w", "--workspace", "workspace_id", help="PowerBI workspace ID")
+@option("-w", "--workspace", "workspace_id", help="PowerBI workspace ID", type=QueryType())
 def update_credentials(ctx: Context, powerbi_workspace_id: str, dataset_id: str, workspace_id: str) -> CommandResponse:
     """Update azure credentials of a given datasource"""
     workspace_id = workspace_id or powerbi_workspace_id

--- a/Babylon/groups/powerbi/groups/dataset/groups/parameters/commands/update.py
+++ b/Babylon/groups/powerbi/groups/dataset/groups/parameters/commands/update.py
@@ -19,9 +19,9 @@ logger = logging.getLogger("Babylon")
 @command()
 @pass_context
 @require_deployment_key("powerbi_workspace_id", required=False)
-@argument("dataset_id")
+@argument("dataset_id", type=QueryType())
 @option("-p", "--parameter", "params", type=(str, QueryType()), multiple=True, required=True)
-@option("-w", "--workspace", "workspace_id", help="PowerBI workspace ID")
+@option("-w", "--workspace", "workspace_id", type=QueryType(), help="PowerBI workspace ID")
 def update(ctx: Context,
            powerbi_workspace_id: str,
            dataset_id: str,

--- a/Babylon/groups/powerbi/groups/report/commands/upload.py
+++ b/Babylon/groups/powerbi/groups/report/commands/upload.py
@@ -18,6 +18,7 @@ from ......utils.decorators import require_deployment_key
 from ......utils.decorators import timing_decorator
 from ......utils.response import CommandResponse
 from ......utils.request import oauth_request
+from ......utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
@@ -28,7 +29,7 @@ RETRY_WAIT_TIME = 0.5
 @pass_context
 @require_deployment_key("powerbi_workspace_id", required=False)
 @argument("pbix_filename", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-w", "--workspace", "workspace_id", help="PowerBI workspace ID")
+@option("-w", "--workspace", "workspace_id", type=QueryType(), help="PowerBI workspace ID")
 @timing_decorator
 def upload(ctx: Context,
            powerbi_workspace_id: str,

--- a/Babylon/groups/webapp/commands/deploy.py
+++ b/Babylon/groups/webapp/commands/deploy.py
@@ -42,9 +42,8 @@ def deploy(deployment_name: str,
             is_required=False, run_if=enable_powerbi)
 
     # Wait for workflow file to be created by static webapp
-    workflow_file = (
-        "webapp_src/.github/workflows/azure-static-web-apps-"
-        f"{m.env.convert_data_query('%datastore%hostname')}.yml")
+    workflow_file = ("webapp_src/.github/workflows/azure-static-web-apps-"
+                     f"{m.env.convert_data_query('%datastore%hostname')}.yml")
     while not Path(workflow_file).exists():
         m.step(["webapp", "download", "webapp_src"])
 

--- a/Babylon/groups/webapp/commands/deploy.py
+++ b/Babylon/groups/webapp/commands/deploy.py
@@ -43,7 +43,7 @@ def deploy(deployment_name: str,
     env.configuration.set_deploy_var("webapp_registration_id", app_registration_id)
 
     logger.info("3 - Add App Registration to PowerBI group")
-    r_pbigrp = run_command(["azure", "ad", "group", "member", azure_powerbi_group_id, app_registration_id])
+    r_pbigrp = run_command(["azure", "ad", "group", "member", "add", azure_powerbi_group_id, app_registration_id])
     if r_pbigrp.has_failed():
         logger.warning(f"3 - Failed to add app registration {app_registration_id} to AD group PowerBi")
 

--- a/Babylon/groups/webapp/commands/deploy.py
+++ b/Babylon/groups/webapp/commands/deploy.py
@@ -33,6 +33,8 @@ def deploy(deployment_name: str,
         .step(
             ["azure", "appinsight", "create", f"Insight{deployment_name}WebApp"],
             store_at="insights", run_if=webapp_enable_insights) \
+        .step(["config", "deployment", "set-variable", "webapp_insights_instrumentation_key",
+               "%datastore%insights.properties.InstrumentationKey"], run_if=webapp_enable_insights) \
         .wait(5) \
         .step(
             ["azure", "ad", "group", "member", "add", azure_powerbi_group_id, "%datastore%app.data.id"],

--- a/Babylon/groups/webapp/commands/download.py
+++ b/Babylon/groups/webapp/commands/download.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("Babylon")
 def download(webapp_repository: str,
              webapp_repository_branch: str,
              github_token: str,
-             destination_folder: str,
+             destination_folder: pathlib.Path,
              use_working_dir_file: bool = False) -> CommandResponse:
     """Download the github repository locally"""
     env = Environment()

--- a/Babylon/groups/webapp/commands/upload_file.py
+++ b/Babylon/groups/webapp/commands/upload_file.py
@@ -4,11 +4,9 @@ import os
 
 from click import command
 from click import argument
-from click import option
 from click import Path
 import git
 
-from ....utils.environment import Environment
 from ....utils.response import CommandResponse
 
 logger = logging.getLogger("Babylon")
@@ -16,16 +14,8 @@ logger = logging.getLogger("Babylon")
 
 @command()
 @argument("file", type=Path(path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the file path be relative to Babylon working directory ?")
-def upload_file(file: pathlib.Path, use_working_dir_file: bool = False) -> CommandResponse:
+def upload_file(file: pathlib.Path) -> CommandResponse:
     """Upload a file to the webapp github repository"""
-    env = Environment()
-    if use_working_dir_file:
-        file = env.working_dir.get_file(file)
     # Get parent git repository of the workflow file
     parent_repo = None
     for parent in file.parents:
@@ -33,12 +23,16 @@ def upload_file(file: pathlib.Path, use_working_dir_file: bool = False) -> Comma
             parent_repo = parent
             break
     repo = git.Repo(parent_repo)
-    logger.info(f"Uploading file {file} to remote repository {repo.remotes.origin.url}...")
     # Committing file
-    rel_file = os.path.relpath(file, parent_repo)
-    repo.index.add(rel_file)
-    repo.index.commit(f"Babylon: updated file '{rel_file}'")
+    files = [file]
+    if file.is_dir():
+        files = [f for f in file.glob("*")]
+    for file in files:
+        logger.info(f"Committing file {file}")
+        rel_file = os.path.relpath(file, parent_repo)
+        repo.index.add(rel_file)
+        repo.index.commit(f"Babylon: updated file '{rel_file}'")
     # Pushing commit
     repo.remotes.origin.push()
-    logger.info(f"Successfully uploaded file {file} to remote repository {repo.remotes.origin.url}")
+    logger.info("Successfully uploaded files to remote repository")
     return CommandResponse.success()

--- a/Babylon/utils/command_helper.py
+++ b/Babylon/utils/command_helper.py
@@ -23,7 +23,5 @@ def run_command(command_line: list[str], log_level: int = logging.WARNING) -> Co
     name, cmd, args = babylon.resolve_command(ctx, command_line)
     cmd.parse_args(ctx, args)
     ret = cmd.invoke(ctx)
-    if ret.has_failed():
-        logger.error(f"Command {name} has failed")
     logger.setLevel(old_log_level)
     return ret

--- a/Babylon/utils/macro.py
+++ b/Babylon/utils/macro.py
@@ -48,6 +48,18 @@ class Macro():
             self._env.store_data(store_at.split("."), self._responses[-1].to_dict())
         return self
 
+    def iterate(self, command_line: list[str], iterate_on: str, optional: bool = False):
+        """Iterates a command over a query"""
+        query: list[str] = self._env.convert_data_query(iterate_on)
+        if not isinstance(query, list):
+            logger.warning(f"Could not iterate on {iterate_on}")
+            if not optional:
+                self._status = self.STATUS_ERROR
+            return self
+        for item in query:
+            self.step([*command_line, item], optional)
+        return self
+
     def wait(self, delay: int):
         """Wait"""
         if self._status == self.STATUS_ERROR:

--- a/Babylon/utils/macro.py
+++ b/Babylon/utils/macro.py
@@ -91,12 +91,10 @@ class Macro():
         path = Path(output_file)
         output_path = path
         # Get an available filename of the form output_file_xxxx.json
-        idx = 0
-        while True:
-            if not output_path.exists():
-                break
-            idx += 1
+        idx = 1
+        while output_path.exists():
             output_path = path.with_stem(f"{path.stem}_{idx}")
+            idx += 1
         with open(output_path, "w") as _f:
             json.dump(compiled, _f, indent=4)
         logger.info(f"Macro report was dumped in file: {output_path}")

--- a/Babylon/utils/macro.py
+++ b/Babylon/utils/macro.py
@@ -1,0 +1,71 @@
+import json
+import logging
+from typing import Any
+from typing import Optional
+from pathlib import Path
+from time import sleep
+
+from .response import CommandResponse
+from .command_helper import run_command
+from .environment import Environment
+
+logger = logging.getLogger("Babylon")
+
+
+class Macro():
+    """Handles Macro Command Chaining
+    """
+    STATUS_OK = 0
+    STATUS_ERROR = 1
+
+    def __init__(self, name: str):
+        self.name = name
+        self._responses: list[CommandResponse] = []
+        self._env = Environment()
+        self._status = self.STATUS_OK
+
+    def step(self,
+             command_line: list[str],
+             optional: bool = False,
+             store_at: Optional[str] = None,
+             run_if: bool = True) -> Any:
+        """
+        Run a command while allowing method chaining
+        Macro()
+            .step(["api", "organization", "get-all"])
+            .step(["azure", "acr", "list", "-d", "src"])
+            .dump("report.json")
+        """
+        if self._status != self.STATUS_OK or not run_if:
+            logger.warning(f"Skipping command {' '.join(command_line)}...")
+            return self
+        logger.info(f"Running command {' '.join(command_line)}")
+        self._responses.append(run_command(command_line))
+        if not optional and self._responses[-1].has_failed():
+            self._status = self.STATUS_ERROR
+            return self
+        if store_at:
+            self._env.store_data(store_at.split("."), self._responses[-1].to_dict())
+        return self
+
+    def wait(self, delay: int):
+        """Wait"""
+        if self._status == self.STATUS_ERROR:
+            return self
+        logger.info(f"Waiting {delay}s...")
+        sleep(delay)
+        return self
+
+    def dump(self, output_file: str):
+        """Dump command responses data in a json file"""
+        compiled = [{"header": self.name}]
+        compiled.extend([response.to_dict() for response in self._responses])
+        path = Path(output_file)
+        output_path = path
+        for idx in range(1, 10000):
+            if not output_path.exists():
+                break
+            output_path = path.with_stem(f"{path.stem}_{idx}")
+        with open(output_path, "w") as _f:
+            json.dump(compiled, _f, indent=4)
+        logger.info(f"Macro report was dumped in file: {output_path}")

--- a/Babylon/utils/macro.py
+++ b/Babylon/utils/macro.py
@@ -21,7 +21,7 @@ class Macro():
     def __init__(self, name: str):
         self.name = name
         self._responses: list[CommandResponse] = []
-        self._env = Environment()
+        self.env = Environment()
         self._status = self.STATUS_OK
 
     def step(self,
@@ -45,19 +45,7 @@ class Macro():
             self._status = self.STATUS_ERROR
             return self
         if store_at:
-            self._env.store_data(store_at.split("."), self._responses[-1].to_dict())
-        return self
-
-    def iterate(self, command_line: list[str], iterate_on: str, optional: bool = False):
-        """Iterates a command over a query"""
-        query: list[str] = self._env.convert_data_query(iterate_on)
-        if not isinstance(query, list):
-            logger.warning(f"Could not iterate on {iterate_on}")
-            if not optional:
-                self._status = self.STATUS_ERROR
-            return self
-        for item in query:
-            self.step([*command_line, item], optional)
+            self.env.store_data(store_at.split("."), self._responses[-1].to_dict())
         return self
 
     def wait(self, delay: int):

--- a/Babylon/utils/response.py
+++ b/Babylon/utils/response.py
@@ -55,3 +55,19 @@ class CommandResponse():
     @classmethod
     def success(cls, data: Optional[dict[str, Any]] = None) -> Any:
         return cls(status_code=CommandResponse.STATUS_OK, data=data)
+
+class MacroReport():
+    """Contains commands, statuses and data output from macros
+    """
+    def __init__(self):
+        self._commands: dict[str, CommandResponse] = {}
+
+    def addCommand(self, name: str, cmd: CommandResponse):
+        self._commands[name] = cmd
+
+    def dump(self, output_file: str):
+        """Dump command responses data in a json file"""
+        compiled = {k: response.data for k, response in self._commands.items()}
+        with open(output_file, "w") as _f:
+            json.dump(compiled, _f, indent=4)
+        logger.info(f"Macro report was dumped in file: {output_file}")

--- a/Babylon/utils/response.py
+++ b/Babylon/utils/response.py
@@ -2,6 +2,7 @@ from typing import Any
 from typing import Optional
 import json
 import logging
+from pathlib import Path
 
 from click import get_current_context
 
@@ -56,6 +57,7 @@ class CommandResponse():
     def success(cls, data: Optional[dict[str, Any]] = None) -> Any:
         return cls(status_code=CommandResponse.STATUS_OK, data=data)
 
+
 class MacroReport():
     """Contains commands, statuses and data output from macros
     """
@@ -68,6 +70,12 @@ class MacroReport():
     def dump(self, output_file: str):
         """Dump command responses data in a json file"""
         compiled = {k: response.data for k, response in self._commands.items()}
-        with open(output_file, "w") as _f:
+        path = Path(output_file)
+        output_path = path
+        for idx in range(1, 10000):
+            if not output_path.exists():
+                break
+            output_path = path.with_stem(f"{path.stem}_{idx}")
+        with open(output_path, "w") as _f:
             json.dump(compiled, _f, indent=4)
-        logger.info(f"Macro report was dumped in file: {output_file}")
+        logger.info(f"Macro report was dumped in file: {output_path}")

--- a/Babylon/utils/response.py
+++ b/Babylon/utils/response.py
@@ -2,7 +2,6 @@ from typing import Any
 from typing import Optional
 import json
 import logging
-from pathlib import Path
 
 from click import get_current_context
 
@@ -21,7 +20,7 @@ class CommandResponse():
         self.data: dict[str, Any] = data or {}
         ctx = get_current_context()
         self.command = ctx.command_path.split(" ")
-        self.params = ctx.params
+        self.params = {k: str(v) for k, v in ctx.params.items()}
 
     def to_dict(self) -> dict[str, Any]:
         return {"command": self.command, "params": self.params, "status_code": self.status_code, "data": self.data}
@@ -56,26 +55,3 @@ class CommandResponse():
     @classmethod
     def success(cls, data: Optional[dict[str, Any]] = None) -> Any:
         return cls(status_code=CommandResponse.STATUS_OK, data=data)
-
-
-class MacroReport():
-    """Contains commands, statuses and data output from macros
-    """
-    def __init__(self):
-        self._commands: dict[str, CommandResponse] = {}
-
-    def addCommand(self, name: str, cmd: CommandResponse):
-        self._commands[name] = cmd
-
-    def dump(self, output_file: str):
-        """Dump command responses data in a json file"""
-        compiled = {k: response.data for k, response in self._commands.items()}
-        path = Path(output_file)
-        output_path = path
-        for idx in range(1, 10000):
-            if not output_path.exists():
-                break
-            output_path = path.with_stem(f"{path.stem}_{idx}")
-        with open(output_path, "w") as _f:
-            json.dump(compiled, _f, indent=4)
-        logger.info(f"Macro report was dumped in file: {output_path}")

--- a/tests/utils/test_macro.py
+++ b/tests/utils/test_macro.py
@@ -6,6 +6,21 @@ from Babylon.utils.macro import Macro
 
 def test_macro_init():
     """Testing macro"""
-    ctx = click.Context(main)
-    with ctx:
+    with click.Context(main):
         Macro("test").step(["config", "display"])
+
+
+def test_macro_then():
+    """Testing macro"""
+    with click.Context(main):
+        m = Macro("test").then(lambda m: {"test": "data"}, store_at="data")
+    assert m.env.convert_data_query("%datastore%data.test") == "data"
+
+
+def test_macro_iterate():
+    """Testing macro"""
+    with click.Context(main):
+        m = Macro("test")
+        m.env.store_data(["list"], ["hello", "world"])
+        m.iterate("%datastore%list", ["config", "deployment", "set-variable", "test", "%datastore%item"])
+    assert m.env.convert_data_query("%deploy%test") == "world"

--- a/tests/utils/test_macro.py
+++ b/tests/utils/test_macro.py
@@ -1,0 +1,11 @@
+import click
+
+from Babylon.main import main
+from Babylon.utils.macro import Macro
+
+
+def test_macro_init():
+    """Testing macro"""
+    ctx = click.Context(main)
+    with ctx:
+        Macro("test").step(["config", "display"])

--- a/tests/utils/test_response.py
+++ b/tests/utils/test_response.py
@@ -1,6 +1,9 @@
 import click
+from unittest.mock import patch
+from pathlib import PosixPath
 
 from Babylon.utils.response import CommandResponse
+from Babylon.utils.response import MacroReport
 
 
 def test_response_empty():
@@ -42,3 +45,25 @@ def test_response_json():
     with ctx:
         response = CommandResponse.success({"oups": True})
         response.toJSON()
+
+
+def test_report_ok():
+    """Testing macro report"""
+    report = MacroReport()
+    ctx = click.Context(click.Command('cmd'))
+    with ctx:
+        report.addCommand("step 1", CommandResponse.success({"data": 1}))
+    with patch("builtins.open") as file:
+        report.dump("test.json")
+        file.assert_called_with(PosixPath("test.json"), "w")
+
+
+def test_report_duplicate():
+    """Testing macro report"""
+    report = MacroReport()
+    ctx = click.Context(click.Command('cmd'))
+    with ctx:
+        report.addCommand("step 1", CommandResponse.success({"data": 1}))
+    with patch("builtins.open") as file, patch("pathlib.Path.exists", lambda path: path == PosixPath("test.json")):
+        report.dump("test.json")
+        file.assert_called_with(PosixPath("test_1.json"), "w")

--- a/tests/utils/test_response.py
+++ b/tests/utils/test_response.py
@@ -1,9 +1,6 @@
 import click
-from unittest.mock import patch
-from pathlib import PosixPath
 
 from Babylon.utils.response import CommandResponse
-from Babylon.utils.response import MacroReport
 
 
 def test_response_empty():
@@ -45,25 +42,3 @@ def test_response_json():
     with ctx:
         response = CommandResponse.success({"oups": True})
         response.toJSON()
-
-
-def test_report_ok():
-    """Testing macro report"""
-    report = MacroReport()
-    ctx = click.Context(click.Command('cmd'))
-    with ctx:
-        report.addCommand("step 1", CommandResponse.success({"data": 1}))
-    with patch("builtins.open") as file:
-        report.dump("test.json")
-        file.assert_called_with(PosixPath("test.json"), "w")
-
-
-def test_report_duplicate():
-    """Testing macro report"""
-    report = MacroReport()
-    ctx = click.Context(click.Command('cmd'))
-    with ctx:
-        report.addCommand("step 1", CommandResponse.success({"data": 1}))
-    with patch("builtins.open") as file, patch("pathlib.Path.exists", lambda path: path == PosixPath("test.json")):
-        report.dump("test.json")
-        file.assert_called_with(PosixPath("test_1.json"), "w")


### PR DESCRIPTION
Added a method chaining behavior to Macros

Example: Gets the workspace with the specified name and sets its id in config, then dumps command details in a json file
```python
from Babylon.utils import Macro

Macro("my macro") \
    .step(["powerbi", "workspace", "get", "-n", "my_workspace"], store_at="workspace") \
    .step(["config", "deployment", "set-variable", "workspace_id", "%datastore%workspace.data.id")  \
    .dump("set_workspace.json")
```