### PR TITLE
Changed run_command to ignore additional options

### DIFF
--- a/Babylon/commands/config/display.py
+++ b/Babylon/commands/config/display.py
@@ -11,5 +11,6 @@ logger = logging.getLogger("Babylon")
 @command()
 def display() -> CommandResponse:
     """Display current config"""
-    logger.info(str(Environment().configuration))
-    return CommandResponse.success()
+    config = Environment().configuration
+    logger.info(str(config))
+    return CommandResponse.success({"deployment": config.get_deploy(), "platform": config.get_platform()})

--- a/Babylon/utils/command_helper.py
+++ b/Babylon/utils/command_helper.py
@@ -23,7 +23,7 @@ def run_command(command_line: list[str], log_level: int = logging.WARNING) -> Co
     else:
         root = context.find_root()
     babylon = root.command
-    ctx = babylon.make_context("babylon", command_line)
+    ctx = babylon.make_context("babylon", command_line, ignore_unknown_options=True)
     ret: CommandResponse = babylon.invoke(ctx)
     logger.setLevel(old_log_level)
     return ret

--- a/tests/utils/test_macro.py
+++ b/tests/utils/test_macro.py
@@ -2,12 +2,26 @@ import click
 
 from Babylon.main import main
 from Babylon.utils.macro import Macro
+import os
 
 
 def test_macro_init():
     """Testing macro"""
     with click.Context(main):
-        Macro("test").step(["--tests", "config", "display"])
+        m = Macro("test").step(["--tests", "config", "display"])
+    assert m._status == m.STATUS_OK
+
+
+def test_macro_basic():
+    """Testing macro"""
+    with click.Context(main):
+        m = Macro("test") \
+            .step(["--tests", "config", "deployment", "set-variable", "hello", "world"]) \
+            .step(["--tests", "config", "display"])
+    world = m.env.configuration.get_deploy().get("hello")
+    m.env.configuration.set_deploy_var("hello", None)
+    assert world == "world"
+    assert m._status == m.STATUS_OK
 
 
 def test_macro_then():
@@ -19,6 +33,7 @@ def test_macro_then():
 
 def test_macro_iterate():
     """Testing macro"""
+    os.environ["BABYLON_CONFIG_DIRECTORY"] = "tests/environments/Default"
     with click.Context(main):
         m = Macro("test")
         m.env.store_data(["list"], ["hello", "world"])


### PR DESCRIPTION
# Changelog
- Fixed running command from outside of babylon context (pytest) fails
- Added command response data for config display
- Added tests in test macro