### PR TITLE
Added command to send multiple variables in TFC from a file

### DIFF
--- a/.yapfignore
+++ b/.yapfignore
@@ -1,2 +1,1 @@
-**/__init__.py
 build

--- a/Babylon/commands/api/__init__.py
+++ b/Babylon/commands/api/__init__.py
@@ -13,13 +13,7 @@ def api():
     pass
 
 
-list_groups = [
-    workspace,
-    dataset,
-    connector,
-    organization,
-    solution
-]
+list_groups = [workspace, dataset, connector, organization, solution]
 
 for _group in list_groups:
     api.add_command(_group)

--- a/Babylon/commands/azure/__init__.py
+++ b/Babylon/commands/azure/__init__.py
@@ -12,16 +12,7 @@ from .appinsight import appinsight
 
 logger = logging.getLogger("Babylon")
 
-list_groups = [
-    ad,
-    staticwebapp,
-    arm,
-    storage,
-    acr,
-    adt,
-    adx,
-    appinsight
-]
+list_groups = [ad, staticwebapp, arm, storage, acr, adt, adx, appinsight]
 
 
 @c_group()

--- a/Babylon/commands/azure/ad/app/__init__.py
+++ b/Babylon/commands/azure/ad/app/__init__.py
@@ -8,14 +8,7 @@ from .get_principal import get_principal
 from .get import get
 from .update import update
 
-list_commands = [
-    create,
-    delete,
-    get_all,
-    get_principal,
-    get,
-    update
-]
+list_commands = [create, delete, get_all, get_principal, get, update]
 
 list_groups = [password]
 

--- a/Babylon/commands/azure/appinsight/__init__.py
+++ b/Babylon/commands/azure/appinsight/__init__.py
@@ -5,12 +5,7 @@ from .get import get
 from .list import list
 from .create import create
 
-list_commands = [
-    delete,
-    get,
-    list,
-    create
-]
+list_commands = [delete, get, list, create]
 
 
 @group()

--- a/Babylon/commands/powerbi/dataset/__init__.py
+++ b/Babylon/commands/powerbi/dataset/__init__.py
@@ -7,10 +7,7 @@ from .get_all import get_all
 from .update_credentials import update_credentials
 from .parameters import parameters
 
-list_groups = [
-    parameters
-]
-
+list_groups = [parameters]
 
 list_commands = [
     update_credentials,

--- a/Babylon/commands/terraform_cloud/workspace/vars/__init__.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/__init__.py
@@ -1,12 +1,14 @@
 from click import group
 
 from .create import create
+from .create_from_file import create_from_file
 from .delete import delete
 from .get import get
 from .get_all import get_all
 from .update import update
 
 list_commands = [
+    create_from_file,
     create,
     delete,
     get_all,

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -1,0 +1,68 @@
+import json
+import logging
+import pprint
+from typing import Optional
+import pathlib
+
+from click import Path
+from click import argument
+from click import command
+from click import option
+from terrasnek.api import TFC
+from terrasnek.exceptions import TFCHTTPUnprocessableEntity
+
+from .....utils.decorators import describe_dry_run
+from .....utils.decorators import timing_decorator
+from .....utils.decorators import working_dir_requires_yaml_key
+from .....utils.typing import QueryType
+from .....utils.response import CommandResponse
+from .....utils.clients import pass_tfc_client
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@pass_tfc_client
+@option("-w", "--workspace", "workspace_id", help="Id of the workspace to use", type=QueryType())
+@working_dir_requires_yaml_key("terraform_workspace.yaml", "workspace_id", "workspace_id_wd")
+@describe_dry_run("Sending multiple variable creation payloads to terraform")
+@argument("variable_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
+@timing_decorator
+def create_from_file(tfc_client: TFC, workspace_id_wd: str, workspace_id: Optional[str],
+                     variable_file: pathlib.Path) -> CommandResponse:
+    """Set multiple variables in a workspace
+
+More information on the arguments can be found at :
+https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-body"""
+
+    workspace_id = workspace_id_wd or workspace_id
+
+    var_payload = {
+        "data": {
+            "type": "vars",
+            "attributes": {
+                "key": None,
+                "value": None,
+                "description": None,
+                "category": None,
+                "hcl": False,
+                "sensitive": False
+            }
+        }
+    }
+    with open(variable_file, "r", encoding="utf-8") as _f:
+        variables = json.load(_f)
+    for variable in variables:
+        if set(var_payload["data"]["attributes"].keys()) <= set(variable.keys()):
+            logger.error(f"TFC variable is missing required fields {list(var_payload['data']['attributes'].keys())}")
+            return CommandResponse.fail()
+        payload = {"data": {"type": "vars", "attributes": variable}}
+        try:
+            tfc_client.workspace_vars.create(workspace_id=workspace_id, payload=payload)
+        except TFCHTTPUnprocessableEntity as _error:
+            logger.error(
+                f"An issue appeared while processing variable {variable.get('key')} for workspace {workspace_id}:")
+            logger.error(pprint.pformat(_error.args))
+            return CommandResponse.fail()
+        logger.info(f"Variable {variable.get('key')} was correctly set for workspace {workspace_id}")
+    return CommandResponse.success(variables)

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -46,25 +46,13 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
 
     workspace_id = workspace_id_wd or workspace_id
 
-    var_payload = {
-        "data": {
-            "type": "vars",
-            "attributes": {
-                "key": None,
-                "value": None,
-                "description": None,
-                "category": None,
-                "hcl": False,
-                "sensitive": False
-            }
-        }
-    }
+    var_payload = {"key": None, "value": None, "description": None, "category": None, "hcl": False, "sensitive": False}
     env = Environment()
     variables = json.loads(env.fill_template(variable_file))
     for variable in variables:
-        if set(var_payload["data"]["attributes"].keys()) <= set(variable.keys()):
-            logger.error(f"TFC variable is missing required fields {list(var_payload['data']['attributes'].keys())}")
-            return CommandResponse.fail()
+        if not set(variable.keys()) <= var_payload.keys():
+            logger.error(f"TFC variable is missing required fields {list(var_payload.keys())}")
+            continue
         payload = {"data": {"type": "vars", "attributes": variable}}
         try:
             tfc_client.workspace_vars.create(workspace_id=workspace_id, payload=payload)
@@ -72,6 +60,6 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
             logger.error(
                 f"An issue appeared while processing variable {variable.get('key')} for workspace {workspace_id}:")
             logger.error(pprint.pformat(_error.args))
-            return CommandResponse.fail()
+            continue
         logger.info(f"Variable {variable.get('key')} was correctly set for workspace {workspace_id}")
     return CommandResponse.success(variables)

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -38,8 +38,8 @@ def create_from_file(tfc_client: TFC, workspace_id_wd: str, workspace_id: Option
         "value": "",
         "description": "",
         "category": "",
-        "hcl": False,
-        "sensitive": False
+        "hcl": false,
+        "sensitive": false
     }]
 More information on the arguments can be found at :
 https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-body"""

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -32,7 +32,15 @@ logger = logging.getLogger("Babylon")
 def create_from_file(tfc_client: TFC, workspace_id_wd: str, workspace_id: Optional[str],
                      variable_file: pathlib.Path) -> CommandResponse:
     """Set multiple variables in a workspace
-
+    Variable file must be a json file containing an array of the following json objects
+    [{
+        "key": "",
+        "value": "",
+        "description": "",
+        "category": "",
+        "hcl": False,
+        "sensitive": False
+    }]
 More information on the arguments can be found at :
 https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-body"""
 

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -17,6 +17,7 @@ from .....utils.decorators import working_dir_requires_yaml_key
 from .....utils.typing import QueryType
 from .....utils.response import CommandResponse
 from .....utils.clients import pass_tfc_client
+from .....utils.environment import Environment
 
 logger = logging.getLogger("Babylon")
 
@@ -50,8 +51,8 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
             }
         }
     }
-    with open(variable_file, "r", encoding="utf-8") as _f:
-        variables = json.load(_f)
+    env = Environment()
+    variables = json.loads(env.fill_template(variable_file))
     for variable in variables:
         if set(var_payload["data"]["attributes"].keys()) <= set(variable.keys()):
             logger.error(f"TFC variable is missing required fields {list(var_payload['data']['attributes'].keys())}")

--- a/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
+++ b/Babylon/commands/terraform_cloud/workspace/vars/create_from_file.py
@@ -37,7 +37,7 @@ def create_from_file(tfc_client: TFC, workspace_id_wd: str, workspace_id: Option
         "key": "",
         "value": "",
         "description": "",
-        "category": "",
+        "category": "", [defaults to terraform]
         "hcl": false,
         "sensitive": false
     }]
@@ -50,6 +50,7 @@ https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variables#request-
     env = Environment()
     variables = json.loads(env.fill_template(variable_file))
     for variable in variables:
+        variable.setdefault("category", "terraform")
         if not set(variable.keys()) <= var_payload.keys():
             logger.error(f"TFC variable is missing required fields {list(var_payload.keys())}")
             continue

--- a/plugins/dev_tools/__init__.py
+++ b/plugins/dev_tools/__init__.py
@@ -14,15 +14,11 @@ from .parameter_value import parameter_value
 from .initialize_plugin import initialize_plugin
 from .tests import tests
 
-list_commands = [
-    parameter_value,
-    initialize_plugin
-]
+list_commands = [parameter_value, initialize_plugin]
 
 list_groups = [
     tests,
 ]
-
 
 logger = logging.getLogger("Babylon")
 

--- a/plugins/dev_tools/tests/__init__.py
+++ b/plugins/dev_tools/tests/__init__.py
@@ -2,9 +2,7 @@ from click import group
 
 from .how_to import how_to
 
-list_commands = [
-    how_to
-]
+list_commands = [how_to]
 
 
 @group()


### PR DESCRIPTION
```bash
babylon terraform-cloud workspace vars create-from-file [my_file.json]
```
With the following file content, this file supports babylon queries with jmespath
```json
[
  {
    "key": "api_scope",
    "value": "%deploy%api_scope",
    "description": "",
    "category": "",
    "hcl": "",
    "sensitive": ""
  },
  {
    "key": "",
    "value": "",
    "description": "",
    "category": "",
    "hcl": "",
    "sensitive": ""
  },
  {
    "key": "",
    "value": "",
    "description": "",
    "category": "",
    "hcl": "",
    "sensitive": ""
  }
]
```