### PR TITLE
Improved WebApp templates

### DIFF
--- a/Babylon/commands/azure/ad/app/create.py
+++ b/Babylon/commands/azure/ad/app/create.py
@@ -4,6 +4,7 @@ import pathlib
 from click import command
 from click import option
 from click import Path
+from click import argument
 from rich.pretty import pretty_repr
 
 from .....utils.request import oauth_request
@@ -11,30 +12,26 @@ from .....utils.response import CommandResponse
 from .....utils.environment import Environment
 from .....utils.decorators import output_to_file
 from .....utils.credentials import pass_azure_token
+from .....utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
-
-DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/app_registration.json"
 
 
 @command()
 @pass_azure_token("graph")
+@argument("name", type=QueryType())
 @option("-f", "--file", "registration_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the parameter file path be relative to Babylon working directory ?")
 @output_to_file
-def create(azure_token: str, registration_file: pathlib.Path, use_working_dir_file: bool = False) -> CommandResponse:
+def create(azure_token: str, name: str, registration_file: pathlib.Path) -> CommandResponse:
     """
     Register an app in active directory
     https://learn.microsoft.com/en-us/graph/api/application-post-applications
     """
     route = "https://graph.microsoft.com/v1.0/applications"
     env = Environment()
-    registration_file = registration_file or env.working_dir.get_file(DEFAULT_PAYLOAD_TEMPLATE)
-    details = env.fill_template(registration_file, use_working_dir_file=use_working_dir_file)
+    payload_template = env.working_dir.payload_path / "webapp/app_registration.json"
+    registration_file = registration_file or payload_template
+    details = env.fill_template(registration_file, data={"app_name": name})
     response = oauth_request(route, azure_token, type="POST", data=details)
     if response is None:
         return CommandResponse.fail()

--- a/Babylon/commands/azure/appinsight/create.py
+++ b/Babylon/commands/azure/appinsight/create.py
@@ -14,25 +14,18 @@ from ....utils.typing import QueryType
 
 logger = logging.getLogger('Babylon')
 
-DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/app_insight.json"
-
 
 @command()
 @pass_azure_token()
 @require_platform_key('azure_subscription')
 @require_platform_key('resource_group_name')
 @argument('appinsight_name', type=QueryType())
-@option("-f", "--file", "create_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the parameter file path be relative to Babylon working directory ?")
+@option("-f", "--file", "appinsight_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
 def create(azure_token: str,
            azure_subscription: str,
            resource_group_name: str,
            appinsight_name: str,
-           create_file: Optional[pathlib.Path] = None,
+           appinsight_file: Optional[pathlib.Path] = None,
            use_working_dir_file: bool = False) -> CommandResponse:
     """
     Create a app insight resource in the given resource group
@@ -40,8 +33,8 @@ def create(azure_token: str,
     """
 
     env = Environment()
-    create_file = create_file or env.working_dir.get_file(DEFAULT_PAYLOAD_TEMPLATE)
-    details = env.fill_template(create_file, use_working_dir_file=use_working_dir_file)
+    create_file = appinsight_file or env.working_dir.payload_path / "webapp/app_insight.json"
+    details = env.fill_template(create_file)
     route = (f'https://management.azure.com/subscriptions/{azure_subscription}/resourceGroups/{resource_group_name}/'
              f'providers/Microsoft.Insights/components/{appinsight_name}?api-version=2015-05-01')
 

--- a/Babylon/commands/azure/staticwebapp/app_settings/update.py
+++ b/Babylon/commands/azure/staticwebapp/app_settings/update.py
@@ -16,8 +16,6 @@ from .....utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
-DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/webapp_settings.json"
-
 
 @command()
 @pass_azure_token("powerbi")
@@ -25,24 +23,18 @@ DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/webapp_settings.json"
 @require_platform_key("resource_group_name")
 @argument("webapp_name", type=QueryType())
 @option("-f", "--file", "settings_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the parameter file path be relative to Babylon working directory ?")
 def update(azure_token: str,
            azure_subscription: str,
            resource_group_name: str,
            webapp_name: str,
-           settings_file: pathlib.Path,
-           use_working_dir_file: bool = False) -> CommandResponse:
+           settings_file: pathlib.Path) -> CommandResponse:
     """
     Update static webapp app settings in the given webapp
     https://learn.microsoft.com/en-us/rest/api/appservice/static-sites/create-or-update-static-site
     """
     env = Environment()
-    settings_file = settings_file or env.working_dir.get_file(DEFAULT_PAYLOAD_TEMPLATE)
-    details = env.fill_template(settings_file, use_working_dir_file=use_working_dir_file)
+    settings_file = settings_file or env.working_dir.payload_path / "webapp/webapp_settings.json"
+    details = env.fill_template(settings_file)
     response = oauth_request(
         f"https://management.azure.com/subscriptions/{azure_subscription}/resourceGroups/{resource_group_name}/"
         f"providers/Microsoft.Web/staticSites/{webapp_name}/config/appsettings?api-version=2022-03-01",

--- a/Babylon/commands/azure/staticwebapp/app_settings/update.py
+++ b/Babylon/commands/azure/staticwebapp/app_settings/update.py
@@ -23,10 +23,7 @@ logger = logging.getLogger("Babylon")
 @require_platform_key("resource_group_name")
 @argument("webapp_name", type=QueryType())
 @option("-f", "--file", "settings_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-def update(azure_token: str,
-           azure_subscription: str,
-           resource_group_name: str,
-           webapp_name: str,
+def update(azure_token: str, azure_subscription: str, resource_group_name: str, webapp_name: str,
            settings_file: pathlib.Path) -> CommandResponse:
     """
     Update static webapp app settings in the given webapp

--- a/Babylon/commands/azure/staticwebapp/create.py
+++ b/Babylon/commands/azure/staticwebapp/create.py
@@ -17,33 +17,25 @@ from ....utils.typing import QueryType
 
 logger = logging.getLogger("Babylon")
 
-DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/webapp_details.json"
-
 
 @command()
 @pass_azure_token()
 @require_platform_key("azure_subscription")
 @require_platform_key("resource_group_name")
 @argument("webapp_name", type=QueryType())
-@option("-f", "--file", "create_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the parameter file path be relative to Babylon working directory ?")
+@option("-f", "--file", "swa_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
 def create(azure_token: str,
            azure_subscription: str,
            resource_group_name: str,
            webapp_name: str,
-           create_file: Optional[Path] = None,
-           use_working_dir_file: bool = False) -> CommandResponse:
+           swa_file: Optional[Path] = None) -> CommandResponse:
     """
     Create a static webapp data in the given resource group
     https://learn.microsoft.com/en-us/rest/api/appservice/static-sites/create-or-update-static-site
     """
     env = Environment()
-    create_file = create_file or env.working_dir.get_file(DEFAULT_PAYLOAD_TEMPLATE)
-    details = env.fill_template(create_file, use_working_dir_file=use_working_dir_file)
+    swa_file = swa_file or env.working_dir.payload_path / "webapp/webapp_details.json"
+    details = env.fill_template(swa_file)
     route = (f"https://management.azure.com/subscriptions/{azure_subscription}/resourceGroups/{resource_group_name}/"
              f"providers/Microsoft.Web/staticSites/{webapp_name}?api-version=2022-03-01")
     response = oauth_request(route, azure_token, type="PUT", data=details)

--- a/Babylon/commands/config/__init__.py
+++ b/Babylon/commands/config/__init__.py
@@ -6,8 +6,9 @@ from .deployment import deployment
 from .platform import platform
 from .plugin import plugin
 from .set_variable import set_variable
+from .fill_template import fill_template
 
-list_commands = [validate, display, set_variable]
+list_commands = [validate, display, set_variable, fill_template]
 
 list_groups = [
     plugin,

--- a/Babylon/commands/config/fill_template.py
+++ b/Babylon/commands/config/fill_template.py
@@ -23,8 +23,7 @@ def fill_template(template_path: pathlib.Path, output_file) -> CommandResponse:
     env = Environment()
     filled_tpl = env.fill_template(template_path)
     logger.info(filled_tpl)
-    if not output_file:
-        return CommandResponse.success()
-    with output_file.open("w") as f:
-        f.write(str(filled_tpl))
+    if output_file:
+        with output_file.open("w") as f:
+            f.write(str(filled_tpl))
     return CommandResponse.success()

--- a/Babylon/commands/config/fill_template.py
+++ b/Babylon/commands/config/fill_template.py
@@ -1,0 +1,30 @@
+import pathlib
+import logging
+
+from click import command
+from click import argument
+from click import Path
+from click import option
+
+from ...utils.environment import Environment
+from ...utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@argument("template_path", type=Path(path_type=pathlib.Path, exists=True, dir_okay=False))
+@option("-o",
+        "--output",
+        "output_file",
+        type=Path(path_type=pathlib.Path, dir_okay=False),
+        help="File to which content should be outputted")
+def fill_template(template_path: pathlib.Path, output_file) -> CommandResponse:
+    env = Environment()
+    filled_tpl = env.fill_template(template_path)
+    logger.info(filled_tpl)
+    if not output_file:
+        return CommandResponse.success()
+    with output_file.open("w") as f:
+        f.write(str(filled_tpl))
+    return CommandResponse.success()

--- a/Babylon/commands/webapp/download.py
+++ b/Babylon/commands/webapp/download.py
@@ -3,13 +3,11 @@ import pathlib
 
 from click import command
 from click import argument
-from click import option
 from click import Path
 import git
 
 from ...utils.decorators import require_deployment_key
 from ...utils.decorators import working_dir_requires_yaml_key
-from ...utils.environment import Environment
 from ...utils.response import CommandResponse
 
 logger = logging.getLogger("Babylon")
@@ -20,9 +18,7 @@ logger = logging.getLogger("Babylon")
 @require_deployment_key("webapp_repository_branch")
 @working_dir_requires_yaml_key(".secrets.yaml.encrypt", "github.token", "github_token")
 @argument("destination_folder", type=Path(path_type=pathlib.Path))
-def download(webapp_repository: str,
-             webapp_repository_branch: str,
-             github_token: str,
+def download(webapp_repository: str, webapp_repository_branch: str, github_token: str,
              destination_folder: pathlib.Path) -> CommandResponse:
     """Download the github repository locally"""
     if destination_folder.exists():

--- a/Babylon/commands/webapp/download.py
+++ b/Babylon/commands/webapp/download.py
@@ -20,20 +20,11 @@ logger = logging.getLogger("Babylon")
 @require_deployment_key("webapp_repository_branch")
 @working_dir_requires_yaml_key(".secrets.yaml.encrypt", "github.token", "github_token")
 @argument("destination_folder", type=Path(path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the destination folder path be relative to Babylon working directory ?")
 def download(webapp_repository: str,
              webapp_repository_branch: str,
              github_token: str,
-             destination_folder: pathlib.Path,
-             use_working_dir_file: bool = False) -> CommandResponse:
+             destination_folder: pathlib.Path) -> CommandResponse:
     """Download the github repository locally"""
-    env = Environment()
-    if use_working_dir_file:
-        destination_folder = env.working_dir.path / destination_folder
     if destination_folder.exists():
         logger.warning(f"Local folder {destination_folder} already exists, pulling...")
         repo = git.Repo(destination_folder)

--- a/Babylon/commands/webapp/export_config.py
+++ b/Babylon/commands/webapp/export_config.py
@@ -13,20 +13,13 @@ from ...utils.decorators import output_to_file
 
 logger = logging.getLogger("Babylon")
 
-DEFAULT_PAYLOAD_TEMPLATE = ".payload_templates/webapp/webapp_config.json"
-
 
 @command()
-@option("-f", "--file", "template_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
-@option("-e",
-        "--use-working-dir-file",
-        "use_working_dir_file",
-        is_flag=True,
-        help="Should the output file path be relative to Babylon working directory ?")
+@option("-f", "--file", "config_file", type=Path(readable=True, dir_okay=False, path_type=pathlib.Path))
 @output_to_file
-def export_config(template_file: Optional[pathlib.Path] = None, use_working_dir_file: bool = False) -> CommandResponse:
+def export_config(config_file: Optional[pathlib.Path] = None) -> CommandResponse:
     """Export webapp configuration in a json file"""
     env = Environment()
-    template_file = template_file or pathlib.Path(DEFAULT_PAYLOAD_TEMPLATE)
-    config_data = env.fill_template(template_file, use_working_dir_file=use_working_dir_file)
+    config_file = config_file or env.working_dir.payload_path / "webapp/webapp_config.json"
+    config_data = env.fill_template(config_file)
     return CommandResponse.success(json.loads(config_data))

--- a/Babylon/commands/webapp/upload_file.py
+++ b/Babylon/commands/webapp/upload_file.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("Babylon")
 
 
 @command()
-@argument("file", type=Path(path_type=pathlib.Path))
+@argument("file", type=Path(path_type=pathlib.Path, exists=True))
 def upload_file(file: pathlib.Path) -> CommandResponse:
     """Upload a file to the webapp github repository"""
     # Get parent git repository of the workflow file

--- a/Babylon/commands/working_dir/__init__.py
+++ b/Babylon/commands/working_dir/__init__.py
@@ -9,17 +9,7 @@ from .validate import validate
 from .zip_env import zip_env
 from .generate_secret_key import generate_secret_key
 
-
-list_commands = [
-    decrypt_file,
-    encrypt_file,
-    init,
-    complete,
-    validate,
-    display,
-    zip_env,
-    generate_secret_key
-]
+list_commands = [decrypt_file, encrypt_file, init, complete, validate, display, zip_env, generate_secret_key]
 
 
 @group()

--- a/Babylon/commands/working_dir/__init__.py
+++ b/Babylon/commands/working_dir/__init__.py
@@ -7,6 +7,8 @@ from .display import display
 from .init import init
 from .validate import validate
 from .zip_env import zip_env
+from .generate_secret_key import generate_secret_key
+
 
 list_commands = [
     decrypt_file,
@@ -16,6 +18,7 @@ list_commands = [
     validate,
     display,
     zip_env,
+    generate_secret_key
 ]
 
 

--- a/Babylon/commands/working_dir/generate_secret_key.py
+++ b/Babylon/commands/working_dir/generate_secret_key.py
@@ -1,0 +1,26 @@
+import logging
+import pathlib
+
+from click import command
+from click import option
+from click import confirm
+
+from ...utils.environment import Environment
+from ...utils.response import CommandResponse
+
+logger = logging.getLogger("Babylon")
+
+
+@command()
+@option("-o", "--override", "override", is_flag=True, help="Should override existing secret key")
+def generate_secret_key(override: bool = False) -> CommandResponse:
+    """Generates a new secret key"""
+    wd = Environment().working_dir
+    if override and not confirm("Are you sure you want to override existing secret key?", abort=True):
+        return CommandResponse.fail()
+    if not override and pathlib.Path(".secret.key").exists():
+        logger.error("Secret key already exists. Use -o to override")
+        return CommandResponse.fail()
+    secret_path = wd.generate_secret_key(override=override)
+    logger.info(f"Successfully generated secret key in {secret_path}")
+    return CommandResponse.success()

--- a/Babylon/commands/working_dir/generate_secret_key.py
+++ b/Babylon/commands/working_dir/generate_secret_key.py
@@ -21,6 +21,6 @@ def generate_secret_key(override: bool = False) -> CommandResponse:
     if not override and pathlib.Path(".secret.key").exists():
         logger.error("Secret key already exists. Use -o to override")
         return CommandResponse.fail()
-    secret_path = wd.generate_secret_key(override=override)
-    logger.info(f"Successfully generated secret key in {secret_path}")
+    path = wd.generate_secret_key(override=override)
+    logger.info(f"Successfully generated secret key in {path}")
     return CommandResponse.success()

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/app_insight.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/app_insight.json
@@ -1,6 +1,6 @@
 {
   "kind": "web",
-  "location": "${%deploy%webapp_location}",
+  "location": "${deploy['webapp_location']}",
   "properties": {
     "Application_Type": "web",
     "DisableIpMasking": false,

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/app_registration.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/app_registration.json
@@ -1,21 +1,26 @@
 {
-    "displayName": "Azure${%deploy%deployment_name}WebApp",
+    "displayName": "${app_name}",
     "signInAudience": "AzureADMyOrg",
     "spa": {
         "redirectUris": [
-            "http://localhost:3000/scenario",
-            "${%deploy%webapp_domain}/scenario"
+            "http://localhost:3000/scenario"
+            % if deploy['webapp_domain']: 
+                ,
+                "https://${deploy['webapp_domain']}/scenario"
+            % endif
         ]
     },
     "requiredResourceAccess": [
+        % if platform['csm_platform_app_id']:
         {
-            "resourceAppId": "${%platform%csm_platform_app_id}",
+            "resourceAppId": "${platform['csm_platform_app_id']}",
             "resourceAccess": [
                 {
-                    "id": "${%platform%csm_platform_scope_id}",
+                    "id": "${platform['csm_platform_scope_id']}",
                     "type": "Scope"
                 }
             ]
         }
+        % endif
     ]
 }

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_config.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_config.json
@@ -1,9 +1,9 @@
 {
-    "REACT_APP_AZURE_TENANT_ID": "${%platform%azure_tenant_id}",
-    "REACT_APP_APP_REGISTRATION_CLIENT_ID": "${%deploy%webapp_registration_id}",
-    "REACT_APP_COSMOTECH_API_SCOPE": "${%platform%api_scope}",
-    "REACT_APP_ORGANIZATION_ID": "${%deploy%organization_id}",
-    "REACT_APP_WORKSPACE_ID": "${%deploy%workspace_id}",
-    "REACT_APP_APPLICATION_INSIGHTS_INSTRUMENTATION_KEY": "${%deploy%webapp_insights_instrumentation_key}",
-    "REACT_APP_ENABLE_APPLICATION_INSIGHTS": "${%deploy%webapp_enable_insights}"
+    "REACT_APP_AZURE_TENANT_ID": "${platform['azure_tenant_id']}",
+    "REACT_APP_APP_REGISTRATION_CLIENT_ID": "${deploy['webapp_registration_id']}",
+    "REACT_APP_COSMOTECH_API_SCOPE": "${platform['api_scope']}",
+    "REACT_APP_ORGANIZATION_ID": "${deploy['organization_id']}",
+    "REACT_APP_WORKSPACE_ID": "${deploy['workspace_id']}",
+    "REACT_APP_APPLICATION_INSIGHTS_INSTRUMENTATION_KEY": "${deploy['webapp_insights_instrumentation_key']}",
+    "REACT_APP_ENABLE_APPLICATION_INSIGHTS": "${deploy['webapp_enable_insights']}"
 }

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_details.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_details.json
@@ -1,9 +1,9 @@
 {
-    "location": "${%deploy%webapp_location}",
+    "location": "${deploy['webapp_location']}",
     "properties": {
-        "repositoryUrl": "${%deploy%webapp_repository}",
-        "branch": "${%deploy%webapp_repository_branch}",
-        "repositoryToken": "${%secrets%github.token}",
+        "repositoryUrl": "${deploy['webapp_repository']}",
+        "branch": "${deploy['webapp_repository_branch']}",
+        "repositoryToken": "${secrets['github']['token']}",
         "buildProperties": {
             "appLocation": "/",
             "apiLocation": "api",

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_settings.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_settings.json
@@ -1,10 +1,10 @@
 {
     "properties": {
-        "POWER_BI_SCOPE": "${%deploy%powerbi_api_scope}",
+        "POWER_BI_SCOPE": "${deploy['powerbi_api_scope']}",
         "POWER_BI_AUTHORITY_URI": "https://login.microsoftonline.com/common/v2.0",
-        "POWER_BI_WORKSPACE_ID": "${%deploy%powerbi_workspace_id}",
-        "POWER_BI_CLIENT_ID": "${%secrets%powerbi.client_id}",
-        "POWER_BI_CLIENT_SECRET": "${%secrets%powerbi.client_secret}",
-        "POWER_BI_TENANT_ID": "${%platform%azure_tenant_id}"
+        "POWER_BI_WORKSPACE_ID": "${deploy['powerbi_workspace_id']}",
+        "POWER_BI_CLIENT_ID": "${secrets['powerbi']['client_id']}",
+        "POWER_BI_CLIENT_SECRET": "${secrets['powerbi']['client_secret']}",
+        "POWER_BI_TENANT_ID": "${platform['azure_tenant_id']}"
     }
 }

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import click
 import jmespath
+from mako.template import Template
 
 from .configuration import Configuration
 from .working_dir import WorkingDir
@@ -186,29 +187,18 @@ class Environment(metaclass=SingletonMeta):
 
     def fill_template(self,
                       template_file: pathlib.Path,
-                      data: dict[str, Any] = {},
-                      use_working_dir_file: bool = False) -> str:
+                      data: dict[str, Any] = {}
+                      ) -> str:
         """
-        Fills a template with environment data using queries
+        Fills a template with environment data using mako template engine
+        https://docs.makotemplates.org/en/latest/syntax.html
         :param template_file: Input template file path
         :type template_file: str
         :return: filled template
         """
-        REMOVE_MARKER = "\\REMOVE_LINE\\"
-
-        def lookup_value(match: re.Match[str]) -> str:
-            key = str(match.group(1))
-            value = data.get(key) or self.convert_data_query(key)
-            if not value:
-                logger.warning(f"Missing key {key} in template data, removing line...")
-                return REMOVE_MARKER
-            return value
-
-        if use_working_dir_file:
-            template_file = self.working_dir.get_file(str(template_file))
-        with open(template_file, "r") as _file:
-            template_content = _file.read()
-        filled = re.sub(r"\$\{(.+)\}", lookup_value, template_content)
-        filtered = "\n".join([line for line in filled.split("\n") if REMOVE_MARKER not in line])
-        # Removing last commas for json files
-        return re.sub(r'''(?<=[}\]"']),(?!\s*[{["'])''', "", filtered)
+        template = Template(filename=str(template_file))
+        return template.render(**data,
+                               platform=self.configuration.get_platform(),
+                               deploy=self.configuration.get_deploy(),
+                               datastore=self.data_store,
+                               secrets={})

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -193,9 +193,13 @@ class Environment(metaclass=SingletonMeta):
         :type template_file: str
         :return: filled template
         """
+        try:
+            secrets = self.working_dir.get_file_content(".secrets.yaml.encrypt")
+        except Exception:
+            secrets = {}
         template = Template(filename=str(template_file), strict_undefined=True)
         return template.render(**data,
                                platform=self.configuration.get_platform(),
                                deploy=self.configuration.get_deploy(),
                                datastore=self.data_store,
-                               secrets=self.working_dir.get_file_content(".secrets.yaml.encrypt"))
+                               secrets=secrets)

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -185,10 +185,7 @@ class Environment(metaclass=SingletonMeta):
 
         return _type, _file, _query
 
-    def fill_template(self,
-                      template_file: pathlib.Path,
-                      data: dict[str, Any] = {}
-                      ) -> str:
+    def fill_template(self, template_file: pathlib.Path, data: dict[str, Any] = {}) -> str:
         """
         Fills a template with environment data using mako template engine
         https://docs.makotemplates.org/en/latest/syntax.html
@@ -196,9 +193,9 @@ class Environment(metaclass=SingletonMeta):
         :type template_file: str
         :return: filled template
         """
-        template = Template(filename=str(template_file))
+        template = Template(filename=str(template_file), strict_undefined=True)
         return template.render(**data,
                                platform=self.configuration.get_platform(),
                                deploy=self.configuration.get_deploy(),
                                datastore=self.data_store,
-                               secrets={})
+                               secrets=self.working_dir.get_file_content(".secrets.yaml.encrypt"))

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -193,11 +193,8 @@ class Environment(metaclass=SingletonMeta):
         :type template_file: str
         :return: filled template
         """
-        try:
-            secrets = self.working_dir.get_file_content(".secrets.yaml.encrypt")
-        except Exception:
-            secrets = {}
-        template = Template(filename=str(template_file), strict_undefined=True)
+        secrets = self.working_dir.get_file_content(".secrets.yaml.encrypt")
+        template = Template(filename=str(template_file.absolute()), strict_undefined=True)
         return template.render(**data,
                                platform=self.configuration.get_platform(),
                                deploy=self.configuration.get_deploy(),

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -37,6 +37,7 @@ class WorkingDir:
             self.zip_file = zipfile.ZipFile(self.path)
             self.path = zipfile.Path(self.zip_file)
         self.template_path = TEMPLATE_FOLDER_PATH / "working_dir_template"
+        self.payload_path = self.path / ".payload_templates"
         self.encoding_key = None
 
     def copy_template(self):

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -229,23 +229,24 @@ class WorkingDir:
 
     def load_secret_key(self):
         try:
-            secret_file_path = self.get_file(".secret.key")
-            with open(secret_file_path, "rb") as f:
+            path = self.get_file(".secret.key")
+            with open(path, "rb") as f:
                 self.encoding_key = f.read()
         except OSError:
-            logger.warning("Could not found .secret.key, generate a new one with 'babylon working-dir generate-secret-key'")
+            logger.warning(
+                "Could not found .secret.key, generate a new one with 'babylon working-dir generate-secret-key'")
             raise ValueError(".secret.key file could not be opened")
 
     def generate_secret_key(self, override: bool = False) -> pathlib.Path:
-        secret_file_path = self.get_file(".secret.key")
-        if secret_file_path.exists() and not override:
-            return secret_file_path
+        path = self.get_file(".secret.key")
+        if path.exists() and not override:
+            return path
         generated_key = Fernet.generate_key()
         self.encoding_key = generated_key
-        with open(secret_file_path, "wb") as f:
+        with open(path, "wb") as f:
             f.write(generated_key)
-        logger.warning(f"Generated new secret key `{secret_file_path}` make sure to keep it safe.")
-        return secret_file_path
+        logger.warning(f"Generated new secret key `{path}` make sure to keep it safe.")
+        return path
 
     @staticmethod
     def encrypt_content(encoding_key: bytes, content: bytes) -> bytes:

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -253,8 +253,13 @@ class WorkingDir:
 
     @staticmethod
     def decrypt_content(encoding_key: bytes, content: bytes) -> bytes:
-        decoder = Fernet(encoding_key)
-        return decoder.decrypt(content)
+        try:
+            decoder = Fernet(encoding_key)
+            data = decoder.decrypt(content)
+        except Exception:
+            logger.error("Could not decrypt content, wrong key ?")
+            return b""
+        return data
 
     def decrypt_file(self, file_name: pathlib.Path) -> Any:
         """

--- a/Babylon/utils/working_dir.py
+++ b/Babylon/utils/working_dir.py
@@ -233,6 +233,7 @@ class WorkingDir:
             with open(secret_file_path, "rb") as f:
                 self.encoding_key = f.read()
         except OSError:
+            logger.warning("Could not found .secret.key, generate a new one with 'babylon working-dir generate-secret-key'")
             raise ValueError(".secret.key file could not be opened")
 
     def generate_secret_key(self, override: bool = False) -> pathlib.Path:

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ jmespath>=1.0.1
 terrasnek>=0.1.10
 rich>=12.6.0
 GitPython>=3.1.30
+Mako==1.2.4
 
 # Testing requirements
 pytest>=7.1.3

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -109,23 +109,23 @@ def test_fill_template_raw_ok():
     """Test filling a template"""
     env = Environment()
     with patch("builtins.open", mock_open(read_data="abc_${my_data}_def")):
-        result = env.fill_template(pathlib.Path("test"), {"my_data": "plop"})
+        result = env.fill_template(pathlib.Path("test"), data={"my_data": "plop"})
     assert result == "abc_plop_def"
 
 
 def test_fill_template_raw_empty():
     """Test filling a template"""
     env = Environment()
-    with patch("builtins.open", mock_open(read_data="1\nabc_${my_data}_def\nb\n")):
-        filled = env.fill_template(pathlib.Path("test"), {"oups": "plop"})
-    assert filled == "1\nb\n"
+    with pytest.raises(NameError):
+        with patch("builtins.open", mock_open(read_data="1\nabc_${my_data}_def\nb\n")):
+            env.fill_template(pathlib.Path("test"), {"oups": "plop"})
 
 
 def test_fill_template_config_ok():
     """Test filling a template"""
     env = Environment()
     env.set_configuration(pathlib.Path("tests/environments/Default"))
-    with patch("builtins.open", mock_open(read_data="abc_${%deploy%api_url}_def")):
+    with patch("builtins.open", mock_open(read_data="abc_${deploy['api_url']}_def")):
         result = env.fill_template(pathlib.Path("test"))
     assert result == "abc_azerty.com_def"
 
@@ -134,15 +134,6 @@ def test_fill_template_config_inexists():
     """Test filling a template"""
     env = Environment()
     env.set_configuration(pathlib.Path("tests/environments/Default"))
-    with patch("builtins.open", mock_open(read_data="abc_${%deploy%oups}_def")):
+    with patch("builtins.open", mock_open(read_data="abc_${deploy['oups']}_def")):
         with pytest.raises(KeyError):
             env.fill_template(pathlib.Path("test"))
-
-
-def test_fill_template_config_empty():
-    """Test filling a template"""
-    env = Environment()
-    env.set_configuration(pathlib.Path("tests/environments/Default"))
-    with patch("builtins.open", mock_open(read_data="line1: ${%deploy%organization_id}_def\nline2: 1")):
-        filled = env.fill_template(pathlib.Path("test"))
-    assert filled == "line2: 1"


### PR DESCRIPTION
This is the start of a complete rework of the commands using API calls to use payload templates to facilitate resource configuration.

Here is the workflow:
- User fills configuration files `deploy.yaml` and `platform.yaml`
- User calls a command with additional parameters specific for the command
- The command fills a default payload template located in `.payload_templates` with data from configuration and parameters.
Another template can be given as command argument to use your own payload
-  The command calls the API with the filled payload
- ...

## Changelog
- Added `mako` dependency to add logic in templates.
- Added command `babylon config fill-template` that fills a template with config data.
- Updates command used in `webapp deploy` to use new template system
