### PR TITLE
Fix missing service principal in app registration

### DIFF
--- a/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
+++ b/Babylon/groups/azure/groups/ad/groups/app/commands/create.py
@@ -42,5 +42,12 @@ def create(ctx: Context, registration_file: pathlib.Path, use_working_dir_file: 
     if response is None:
         return CommandResponse.fail()
     output_data = response.json()
+    # Service principal creation
+    sp_route = "https://graph.microsoft.com/v1.0/servicePrincipals"
+    sp_response = oauth_request(sp_route, access_token, type="POST", json={"appId": output_data["appId"]})
+    if sp_response is None:
+        logger.error("Failed to create application service principal")
+        return CommandResponse.fail()
+    output_data["servicePrincipalId"] = sp_response.json()["id"]
     logger.info(pretty_repr(output_data))
     return CommandResponse.success(output_data)

--- a/Babylon/groups/webapp/commands/deploy.py
+++ b/Babylon/groups/webapp/commands/deploy.py
@@ -40,12 +40,13 @@ def deploy(deployment_name: str,
     if r_ar.has_failed():
         return CommandResponse.fail()
     app_registration_id = r_ar.data["id"]
+    service_principal_id = r_ar.data["servicePrincipalId"]
     env.configuration.set_deploy_var("webapp_registration_id", app_registration_id)
 
     logger.info("3 - Add App Registration to PowerBI group")
-    r_pbigrp = run_command(["azure", "ad", "group", "member", "add", azure_powerbi_group_id, app_registration_id])
+    r_pbigrp = run_command(["azure", "ad", "group", "member", "add", azure_powerbi_group_id, service_principal_id])
     if r_pbigrp.has_failed():
-        logger.warning(f"3 - Failed to add app registration {app_registration_id} to AD group PowerBi")
+        logger.warning(f"3 - Failed to add app registration {service_principal_id} to AD group PowerBi")
 
     if webapp_enable_insights is True:
         logger.info("3b - Creating Application insights for Static Web App...")
@@ -93,9 +94,9 @@ def deploy(deployment_name: str,
         logger.warning("7 - Failed to add app registration identifiers for powerBI")
 
     logger.info("9 - Adding App user to powerBI workspace ID...")
-    r_pbiws = run_command(["powerbi", "workspace", "user", "add", r_ar.data["appId"], "App", "Member"])
+    r_pbiws = run_command(["powerbi", "workspace", "user", "add", service_principal_id, "App", "Member"])
     if r_pbiws.has_failed():
-        logger.warning((f"8 - `babylon powerbi workspace user add {r_ar.data['appId']} App Member`",
+        logger.warning((f"8 - `babylon powerbi workspace user add {service_principal_id} App Member`",
                         " failed, make sure you have sufficient rights and retype the command"))
 
     logger.info("10 - Adding powerbi credentials in Static WebApp settings...")


### PR DESCRIPTION
**This PR will be merged in release v2.0.1**
Azure does not create a service principal associated to the app registration by default. 
I made some errors by using the application id instead of a service principal id in `powerbi workspace user add` and `ad group member ad`.

# Changelog
- Added service principal creation api call in `azure ad app create`
- Fixed wrong id used in `webapp deploy`