### PR TITLE
Fix error messages when connection with ssh

### DIFF
--- a/Babylon/groups/api/__init__.py
+++ b/Babylon/groups/api/__init__.py
@@ -19,7 +19,7 @@ from ...utils.decorators import require_platform_key
 def api(ctx: Context, api_scope: str, api_url: str):
     """Group handling communication with the cosmotech API"""
     try:
-        token = DefaultAzureCredential().get_token(api_scope)
+        token = DefaultAzureCredential(exclude_shared_token_cache_credential=True).get_token(api_scope)
     except ClientAuthenticationError:
         # Error message is handled by Azure API
         sys.exit(0)

--- a/Babylon/groups/azure/__init__.py
+++ b/Babylon/groups/azure/__init__.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("Babylon")
 @requires_external_program("az")
 def azure(ctx: Context):
     """Group allowing communication with Microsoft Azure Cloud"""
-    ctx.obj = DefaultAzureCredential()
+    ctx.obj = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
 
 
 for _command in list_commands:

--- a/Babylon/groups/powerbi/__init__.py
+++ b/Babylon/groups/powerbi/__init__.py
@@ -17,7 +17,7 @@ from ...utils.decorators import require_platform_key
 def powerbi(ctx: Context, powerbi_api_scope: str):
     """Group handling communication with PowerBI API"""
     try:
-        token = DefaultAzureCredential().get_token(powerbi_api_scope)
+        token = DefaultAzureCredential(exclude_shared_token_cache_credential=True).get_token(powerbi_api_scope)
     except ClientAuthenticationError:
         # Error message is handled by Azure API
         sys.exit(0)

--- a/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_settings.json
+++ b/Babylon/templates/working_dir_template/.payload_templates/webapp/webapp_settings.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "POWER_BI_SCOPE": "${%deploy%powerbi_api_scope}",
+        "POWER_BI_SCOPE": "${%platform%powerbi_api_scope}",
         "POWER_BI_AUTHORITY_URI": "https://login.microsoftonline.com/common/v2.0",
         "POWER_BI_WORKSPACE_ID": "${%deploy%powerbi_workspace_id}",
         "POWER_BI_CLIENT_ID": "${%workdir[.secrets.yaml]%powerbi.client_id}",


### PR DESCRIPTION
**This will be released in hotfix release 2.0.1**
See issue #154 
I disabled login with TokenCacheCredentials which is left in DefaultAzureCredential only for retro-compatibility with Visual Studio login. We will never use it anyway.

I also added a quick fix where I was referencing powerbi_api_scope from deploy instead of platform
