### PR TITLE
Fix keys conversion fails

### DIFF
--- a/Babylon/utils/api.py
+++ b/Babylon/utils/api.py
@@ -46,18 +46,9 @@ def convert_keys_case(element: Any, convert_function) -> Any:
     :return: an object of the same type as the original one where all dict keys had the convert_function applied
     """
     if isinstance(element, dict):
-        new_element = dict()
-        for k, v in element.items():
-            if k in ["parametersValues", "parameters_values"]:
-                new_element[convert_function(k)] = dict() if not v else v.copy()
-            elif v is not None:
-                new_element[convert_function(k)] = convert_keys_case(v, convert_function)
-        return new_element
+        return {convert_function(k): v or {} for k, v in element.items()}
     if isinstance(element, list):
-        new_element = list()
-        for e in element:
-            new_element.append(convert_keys_case(e, convert_function))
-        return new_element
+        return [convert_keys_case(e, convert_function) for e in element]
     return element
 
 


### PR DESCRIPTION
From [Jira Ticket #1114](https://cosmo-tech.atlassian.net/browse/SDCOSMO-1114)
It appears CosmoSDK expects first level keys to be snake case. 
We were converting all keys so I simply reduced depth to 1.
```
Hi,

trying to cerate a new solution using Babylon I had an issue. I run the following command with the attached file : 

babylon api solution update -i "API/INPUT/Solution_webapp_v5.yaml" 


Solution_webapp_v5.yaml
17 Mar 2023, 04:49 PM
Connector ID was : connectorId

Then in Platform API, connector ID was written: connector_Id

subType was sub_Type, etc

Thanks
```