### PR TITLE
[Utils] Json data and output format 

### DIFF
--- a/Babylon/utils/credentials.py
+++ b/Babylon/utils/credentials.py
@@ -11,6 +11,8 @@ from azure.identity import (
     EnvironmentCredential,
     CredentialUnavailableError,
 )
+
+from .response import CommandResponse
 from .environment import Environment
 
 logger = logging.getLogger("Babylon")
@@ -90,7 +92,10 @@ def pass_azure_token(scope: str = "default") -> Callable[..., Any]:
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any):
-            kwargs["azure_token"] = get_azure_token(scope)
+            try:
+                kwargs["azure_token"] = get_azure_token(scope)
+            except ConnectionError:
+                return CommandResponse().fail()
             return func(*args, **kwargs)
 
         return wrapper

--- a/Babylon/utils/response.py
+++ b/Babylon/utils/response.py
@@ -1,10 +1,10 @@
-from typing import Any
-from typing import Optional
 import json
 import logging
+from typing import Any
+from typing import Optional
 
-from rich.pretty import pprint
 from click import get_current_context
+from rich.pretty import pprint
 
 from .environment import Environment
 
@@ -25,7 +25,7 @@ class CommandResponse():
         self.command = ctx.command_path.split(" ")
         self.params = {k: str(v) for k, v in ctx.params.items()}
         if verbose and Environment().is_verbose:
-            pprint(self.data, max_length=100)
+            pprint(self.data)
 
     def to_dict(self) -> dict[str, Any]:
         return {"command": self.command, "params": self.params, "status_code": self.status_code, "data": self.data}
@@ -39,7 +39,7 @@ class CommandResponse():
         ])
 
     def toJSON(self) -> str:
-        return json.dumps(self.data, indent=4)
+        return json.dumps(self.data, indent=4, ensure_ascii=False)
 
     def dump(self, output_file: str):
         """Dump command response data in a json file"""
@@ -49,9 +49,10 @@ class CommandResponse():
 
     def has_failed(self) -> bool:
         """Checks if command has failed"""
-        if self.status_code != self.STATUS_ERROR:
-            return False
-        return True
+        return self.status_code == self.STATUS_ERROR
+
+    def has_success(self) -> bool:
+        return self.status_code == CommandResponse.STATUS_OK
 
     @classmethod
     def fail(cls, **kwargs) -> Any:

--- a/Babylon/utils/yaml_utils.py
+++ b/Babylon/utils/yaml_utils.py
@@ -13,7 +13,7 @@ def yaml_to_json(yaml_str: str) -> str:
     Converts a yaml string to a json string
     """
     data = yaml.safe_load(yaml_str)
-    return json.dumps(data, indent=4, default=str)
+    return json.dumps(data, indent=4, default=str, ensure_ascii=True)
 
 
 def read_yaml_key(yaml_file: pathlib.Path, key: str) -> Optional[object]:


### PR DESCRIPTION
## Allow non-ASCII in json

In summary, if you use return json.dumps(self.data, indent=4, ensure_ascii=False), it means that if your self.data object contains non-ASCII characters (e.g., accented characters, emojis, etc.), they will be included directly in the JSON output without being escaped into ASCII escape sequences. This can be useful if you need to preserve non-ASCII characters as they are in your JSON.

## Improve authentication error handling for automatic test

## Suppress pprint output max_length

