### PR TITLE
Fixed input file type error TypeError: isinstance() arg 2 must be a type or tuple of types

### DIFF
--- a/Babylon/commands/api/organization/security/update.py
+++ b/Babylon/commands/api/organization/security/update.py
@@ -24,10 +24,8 @@ logger = getLogger("Babylon")
 @require_platform_key("api_url")
 @pass_azure_token("csm_api")
 @option("--organization-id", "organization_id", type=QueryType(), default="%deploy%organization_id")
-@argument(
-    "security_file",
-    type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)
-)
+@argument("security_file",
+          type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path))
 @output_to_file
 def update(api_url: str, azure_token: str, organization_id: str, security_file: pathlib.Path) -> CommandResponse:
     """

--- a/Babylon/commands/api/organization/security/update.py
+++ b/Babylon/commands/api/organization/security/update.py
@@ -26,7 +26,7 @@ logger = getLogger("Babylon")
 @option("--organization-id", "organization_id", type=QueryType(), default="%deploy%organization_id")
 @argument(
     "security_file",
-    type=Path(path_type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)),
+    type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)
 )
 @output_to_file
 def update(api_url: str, azure_token: str, organization_id: str, security_file: pathlib.Path) -> CommandResponse:

--- a/Babylon/commands/api/solution/handler/download.py
+++ b/Babylon/commands/api/solution/handler/download.py
@@ -46,7 +46,7 @@ logger = getLogger("Babylon")
         "--output",
         "output_folder",
         help="Output folder",
-        type=Path(path_type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)))
+        type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path))
 def download(api_url: str, azure_token: str, organization_id: str, solution_id: str, handler_id: str,
              run_template_id: str, output_folder: pathlib.Path) -> CommandResponse:
     """Download a solution handler zip from the solution"""

--- a/Babylon/commands/api/solution/update.py
+++ b/Babylon/commands/api/solution/update.py
@@ -25,7 +25,7 @@ logger = getLogger("Babylon")
 @pass_azure_token("csm_api")
 @option("--solution-id", "solution_id", type=QueryType(), default="%deploy%solution_id")
 @argument("solution_file",
-          type=Path(path_type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)))
+          type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path))
 @option("--organization-id", "organization_id", type=QueryType(), default="%deploy%organization_id")
 @output_to_file
 def update(api_url: str, azure_token: str, organization_id: str, solution_id: str,

--- a/Babylon/commands/api/workspace/security/update.py
+++ b/Babylon/commands/api/workspace/security/update.py
@@ -26,10 +26,8 @@ logger = getLogger("Babylon")
 @pass_azure_token("csm_api")
 @option("--organization", "organization_id", type=QueryType(), default="%deploy%organization_id")
 @option("--workspace", "workspace_id", type=QueryType(), default="%deploy%workspace_id")
-@argument(
-    "security_file",
-    type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)
-)
+@argument("security_file",
+          type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path))
 @output_to_file
 def update(api_url: str, azure_token: str, organization_id: str, workspace_id: str,
            security_file: pathlib.Path) -> CommandResponse:

--- a/Babylon/commands/api/workspace/security/update.py
+++ b/Babylon/commands/api/workspace/security/update.py
@@ -28,8 +28,7 @@ logger = getLogger("Babylon")
 @option("--workspace", "workspace_id", type=QueryType(), default="%deploy%workspace_id")
 @argument(
     "security_file",
-    type=Path(path_type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)),
-    required=True,
+    type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)
 )
 @output_to_file
 def update(api_url: str, azure_token: str, organization_id: str, workspace_id: str,


### PR DESCRIPTION
This error was due to a duplicate tuple in type field

```
|| - type=Path(path_type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path)))
|| +  type=Path(exists=True, file_okay=True, dir_okay=False, readable=True, path_type=pathlib.Path))
```