### PR TITLE
fix getall command

### DIFF
--- a/Babylon/services/organizations_service.py
+++ b/Babylon/services/organizations_service.py
@@ -22,7 +22,6 @@ class OrganizationService:
         if not self.url:
             logger.error("API url not found")
             sys.exit(1)
-        self.security_svc = OrganizationSecurityService(azure_token=azure_token, state=state)
 
     def create(self):
         details = self.spec["payload"]
@@ -67,6 +66,7 @@ class OrganizationService:
         return response
 
     def security(self, data: dict):
+        self.security_svc = OrganizationSecurityService(azure_token=self.azure_token, state=self.state)
         security_spec = self.spec["payload"].get("security")
         if not security_spec:
             logger.error("security is missing")


### PR DESCRIPTION
if we run:

1. babylon api organizations get-all -c test -p dev
2. babylon api organizations get-all -c test -p perf
3. babylon api organizations get-all -c test -p staging

👎🏽 the command doesn't works

fix: we need to move security service to security method in organization service