### PR TITLE
Gestion fonction Azure dans la solution + comportement cohérent création et mise à jour des solutions et espace de travail

### DIFF
--- a/Babylon/commands/api/workspaces/update.py
+++ b/Babylon/commands/api/workspaces/update.py
@@ -1,10 +1,11 @@
 import pathlib
 
 from logging import getLogger
-from typing import Any
+from typing import Any, Optional
 from click import Path, argument
 from click import command
 from click import option
+from Babylon.utils.checkers import check_ascii, check_email
 from Babylon.utils.credentials import pass_azure_token
 from Babylon.utils.decorators import inject_context_with_resource, wrapcontext
 from Babylon.utils.decorators import output_to_file
@@ -28,27 +29,45 @@ env = Environment()
         "workspace_file",
         type=Path(path_type=pathlib.Path),
         help="Your custom workspace description file yaml")
+@option("--email", "security_id", help="Workspace security_id aka email")
+@option("--role", "security_role", required=True, default="admin", help="Workspace security role")
 @argument("id", type=QueryType())
-@inject_context_with_resource({"api": ['url', 'organization_id', 'workspace_id']})
-def update(
-    context: Any,
-    org_id: str,
-    id: str,
-    workspace_file: pathlib.Path,
-    azure_token: str,
-) -> CommandResponse:
+@inject_context_with_resource({
+    "azure": ['email'],
+    "api": ['url', 'organization_id', 'workspace_key', 'workspace_id']
+})
+def update(context: Any,
+           azure_token: str,
+           org_id: str,
+           id: str,
+           workspace_file: pathlib.Path,
+           security_id: Optional[str] = None,
+           security_role: Optional[str] = None) -> CommandResponse:
     """
     Update a workspace
     """
+    security_id = security_id or context['azure_email']
+    check_email(security_id)
     organization_id = org_id or context['api_organization_id']
     workspace_id = id or context['api_workspace_id']
-
+    work_key = context['api_workspace_key']
     path_file = f"{env.context_id}.{env.environ_id}.workspace.yaml"
     workspace_file = workspace_file or env.working_dir.payload_path / path_file
     if not workspace_file.exists():
         logger.info("File not found")
         return CommandResponse.fail()
-    details = env.fill_template(workspace_file)
+    azf_secret = env.get_project_secret(organization_id=context['api_organization_id'].lower(),
+                                        workspace_key=work_key,
+                                        name="func")
+    details = env.fill_template(workspace_file,
+                                data={
+                                    "functionUrl":
+                                    f"{context['api_organization_id'].lower()}-{context['api_workspace_key'].lower()}",
+                                    "key": context['api_workspace_key'],
+                                    "security_id": security_id.lower(),
+                                    "azf_key": azf_secret,
+                                    "security_role": security_role.lower()
+                                })
     response = oauth_request(f"{context['api_url']}/organizations/{organization_id}/workspaces/{workspace_id}",
                              azure_token,
                              type="PATCH",


### PR DESCRIPTION
Bonjour,

afin de me permettre de l'utiliser en attendant la prise en charge « officielle » de ma demande SDCOSMO-1577, et par curiosité afin de connaître de quelle manière vous l'auriez fait plus proprement que ce que j'ai réalisé, je vous soumets en pull-request cette modeste contribution personnelle qui, pour mon cas, me simplifie grandement la vie d'intégrateur et mainteneur de solutions avec l'outil de déploiement Babylon. 

L'objet de ces modifications est double : 

- intégrer la gestion de la fonction Azure dans la solution ;
- assurer un comportement cohérent lors des créations et mises à jour des solutions et espaces de travail : l'objectif est que quelque soit l'opération réalisée, les variables Babylon — {$Cosmotech[]}, mais aussi les $key et autre — soient reconnues et prises en compte.

À ce stade, le développement reste incomplet car je n'ai pas trouvé le temps d'intégrer également la gestion cohérente des ${key}, ${name} et ${tag}, seulement des ${security_id} et ${security_role}.

Selon mes disponibilités, je prendrais le temps plus tard de les traiter également ou bien — je croise les doigts —, vous l'aurez mis en œuvre de votre côté si vous acceptez d'intégrer cette proposition.