### PR TITLE
Improve resource header read in the apply macro

### DIFF
--- a/Babylon/commands/macro/deploy_dataset.py
+++ b/Babylon/commands/macro/deploy_dataset.py
@@ -16,12 +16,12 @@ logger = getLogger("Babylon")
 env = Environment()
 
 
-def deploy_dataset(head: str, file_content: str, deploy_dir: pathlib.Path) -> dict:
+def deploy_dataset(namespace: str, file_content: str, deploy_dir: pathlib.Path) -> dict:
     _ret = [""]
     _ret.append("Dataset deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url = env.get_ns_from_text(content=head)
+    platform_url = env.get_ns_from_text(content=namespace)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state["services"]["azure"]["tenant_id"] = env.tenant_id

--- a/Babylon/commands/macro/deploy_organization.py
+++ b/Babylon/commands/macro/deploy_organization.py
@@ -15,12 +15,12 @@ logger = getLogger("Babylon")
 env = Environment()
 
 
-def deploy_organization(head: str, file_content: str):
+def deploy_organization(namespace: str, file_content: str):
     _ret = [""]
     _ret.append("Organization deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url = env.get_ns_from_text(content=head)
+    platform_url = env.get_ns_from_text(content=namespace)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_solution.py
+++ b/Babylon/commands/macro/deploy_solution.py
@@ -17,12 +17,12 @@ logger = getLogger("Babylon")
 env = Environment()
 
 
-def deploy_solution(head: str, file_content: str, deploy_dir: pathlib.Path) -> bool:
+def deploy_solution(namespace: str, file_content: str, deploy_dir: pathlib.Path) -> bool:
     _ret = [""]
     _ret.append("Solution deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url = env.get_ns_from_text(content=head)
+    platform_url = env.get_ns_from_text(content=namespace)
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_webapp.py
+++ b/Babylon/commands/macro/deploy_webapp.py
@@ -23,12 +23,12 @@ logger = getLogger("Babylon")
 env = Environment()
 
 
-def deploy_swa(head: str, file_content: str):
+def deploy_swa(namespace: str, file_content: str):
     _ret = [""]
     _ret.append("Webapp deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url = env.get_ns_from_text(content=head)
+    platform_url = env.get_ns_from_text(content=namespace)
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_workspace.py
+++ b/Babylon/commands/macro/deploy_workspace.py
@@ -35,12 +35,12 @@ logger = getLogger("Babylon")
 env = Environment()
 
 
-def deploy_workspace(head: str, file_content: str, deploy_dir: pathlib.Path) -> bool:
+def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path) -> bool:
     _ret = [""]
     _ret.append("Workspace deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url = env.get_ns_from_text(content=head)
+    platform_url = env.get_ns_from_text(content=namespace)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state["services"]["azure"]["tenant_id"] = env.tenant_id

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -70,8 +70,7 @@ class Environment(metaclass=SingletonMeta):
         self.working_dir = WorkingDir(working_dir_path=self.pwd)
 
     def get_ns_from_text(self, content: str):
-        result = content.replace("{{", "${").replace("}}", "}")
-        result = result.replace("services", "")
+        result = content.replace("services", "")
         t = Template(text=result, strict_undefined=True)
         values_file = Path().cwd() / "variables.yaml"
         vars = dict()
@@ -79,13 +78,12 @@ class Environment(metaclass=SingletonMeta):
             vars = yaml.safe_load(values_file.open())
         payload = t.render(**vars)
         payload_dict = yaml.safe_load(payload)
-        ns = payload_dict.get("namespace")
-        context_id = ns.get("context", "")
-        state_id = ns.get("state_id", "")
+        context_id = payload_dict.get("context", "")
+        state_id = payload_dict.get("state_id", "")
         if not state_id:
             logger.error("state id is mandatory")
             sys.exit(1)
-        plt_obj = ns.get("platform", {})
+        plt_obj = payload_dict.get("platform", {})
         platform_id = plt_obj.get("id", "")
         if not platform_id:
             logger.error("platform id is mandatory")
@@ -108,8 +106,7 @@ class Environment(metaclass=SingletonMeta):
         return platform_url
 
     def fill_template(self, data: str, state: dict = None, ext_args: dict = None):
-        result = data.replace("{{", "${").replace("}}", "}")
-        t = Template(text=result, strict_undefined=True)
+        t = Template(text=data, strict_undefined=True)
         values_file = Path().cwd() / "variables.yaml"
         vars = dict()
         flattenstate = dict()


### PR DESCRIPTION
Don't hardcode a 7 line header read:
- this allows the 'kind' and 'namespace' to be anywhere in the file not just at the beginning
- this allows the 'namespace' entry to be put in a variable as a block and just its sub-component
- this allows easier future modification of the 'namespace' (adding a sub-entry without modification of the header read code)