### PR TITLE
Add missing minimal required python version (3.10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ urls.Source = "https://github.com/Cosmo-Tech/Babylon"
 urls.Documentation = "https://cosmo-tech.github.io/Babylon/latest/"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 readme = {file = "README.md", content-type = "text/markdown"}
+requires-python = ">=3.10"
 
 [project.scripts]
 babylon = "Babylon.main:main"


### PR DESCRIPTION
trying with python 3.9, install seemed ok, but running babylon failed with syntax error, due to usage of 'match' satement, introduced in python 3.10