### PR TITLE
Add a key to the webapp payload to initialize workspace_key correctly

### DIFF
--- a/Babylon/commands/macro/deploy_dataset.py
+++ b/Babylon/commands/macro/deploy_dataset.py
@@ -21,7 +21,7 @@ def deploy_dataset(namespace: str, file_content: str, deploy_dir: pathlib.Path) 
     _ret.append("Dataset deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url, workspace_key = env.get_ns_from_text(content=namespace)
+    platform_url, workspace_key = env.get_ns_from_text(content=namespace, file_content=file_content)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state["services"]["azure"]["tenant_id"] = env.tenant_id

--- a/Babylon/commands/macro/deploy_organization.py
+++ b/Babylon/commands/macro/deploy_organization.py
@@ -24,7 +24,7 @@ def deploy_organization(namespace: str, file_content: str):
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id
-
+    state["services"]["api"]["workspace_key"] = workspace_key
     azure_token = get_azure_token("csm_api")
     content = env.fill_template(data=file_content, state=state)
     payload: dict = content.get("spec").get("payload", {})

--- a/Babylon/commands/macro/deploy_organization.py
+++ b/Babylon/commands/macro/deploy_organization.py
@@ -20,7 +20,7 @@ def deploy_organization(namespace: str, file_content: str):
     _ret.append("Organization deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url, workspace_key = env.get_ns_from_text(content=namespace)
+    platform_url, workspace_key = env.get_ns_from_text(content=namespace, file_content=file_content)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_solution.py
+++ b/Babylon/commands/macro/deploy_solution.py
@@ -26,7 +26,7 @@ def deploy_solution(namespace: str, file_content: str, deploy_dir: pathlib.Path)
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id
-
+    state["services"]["api"]["workspace_key"] = workspace_key
     state = env.retrieve_state_func()
     azure_token = get_azure_token("csm_api")
     content = env.fill_template(data=file_content, state=state)

--- a/Babylon/commands/macro/deploy_solution.py
+++ b/Babylon/commands/macro/deploy_solution.py
@@ -22,7 +22,7 @@ def deploy_solution(namespace: str, file_content: str, deploy_dir: pathlib.Path)
     _ret.append("Solution deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url, workspace_key = env.get_ns_from_text(content=namespace)
+    platform_url, workspace_key = env.get_ns_from_text(content=namespace, file_content=file_content)
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_webapp.py
+++ b/Babylon/commands/macro/deploy_webapp.py
@@ -28,7 +28,7 @@ def deploy_swa(namespace: str, file_content: str):
     _ret.append("Webapp deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url, workspace_key = env.get_ns_from_text(content=namespace)
+    platform_url, workspace_key = env.get_ns_from_text(content=namespace, file_content=file_content)
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id

--- a/Babylon/commands/macro/deploy_webapp.py
+++ b/Babylon/commands/macro/deploy_webapp.py
@@ -129,7 +129,6 @@ def deploy_swa(namespace: str, file_content: str):
         azure_token = get_azure_token()
         swa_settings = AzureSWASettingsAppService(azure_token=azure_token, state=state.get('services'))
         organization_id = state['services']['api']['organization_id']
-        workspace_key = state['services']['api']['workspace_key'] or payload.get("key")
         secret_powerbi = env.get_project_secret(organization_id=organization_id,
                                                 workspace_key=workspace_key,
                                                 name="pbi")

--- a/Babylon/commands/macro/deploy_webapp.py
+++ b/Babylon/commands/macro/deploy_webapp.py
@@ -129,7 +129,7 @@ def deploy_swa(namespace: str, file_content: str):
         azure_token = get_azure_token()
         swa_settings = AzureSWASettingsAppService(azure_token=azure_token, state=state.get('services'))
         organization_id = state['services']['api']['organization_id']
-        workspace_key = state['services']['api']['workspace_key']
+        workspace_key = state['services']['api']['workspace_key'] or payload.get("key")
         secret_powerbi = env.get_project_secret(organization_id=organization_id,
                                                 workspace_key=workspace_key,
                                                 name="pbi")

--- a/Babylon/commands/macro/deploy_webapp.py
+++ b/Babylon/commands/macro/deploy_webapp.py
@@ -32,10 +32,10 @@ def deploy_swa(namespace: str, file_content: str):
     state = env.retrieve_state_func(state_id=env.state_id)
     state['services']['api']['url'] = platform_url
     state['services']['azure']['tenant_id'] = env.tenant_id
+    state["services"]["api"]["workspace_key"] = workspace_key
     subscription_id = state["services"]["azure"]["subscription_id"]
     github_secret = env.get_global_secret(resource="github", name="token")
     organization_id = state['services']['api']['organization_id']
-    workspace_key = state['services']['api']['workspace_key']
     obi_secret = env.get_project_secret(organization_id=organization_id, workspace_key=workspace_key, name="pbi")
     ext_args = dict(github_secret=github_secret, secret_powerbi=obi_secret)
     file_content_obj = yaml.safe_load(file_content)

--- a/Babylon/commands/macro/deploy_workspace.py
+++ b/Babylon/commands/macro/deploy_workspace.py
@@ -46,7 +46,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state["services"]["azure"]["tenant_id"] = env.tenant_id
-
+    state["services"]["api"]["workspace_key"] = workspace_key
     subscription_id = state["services"]["azure"]["subscription_id"]
     organization_id = state["services"]["api"]["organization_id"]
     workspace_key = workspace_key or state["services"]["api"]["workspace_key"]
@@ -183,7 +183,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
         ok = True
         kusto_client = KustoManagementClient(credential=azure_credential, subscription_id=subscription_id)
         adx_svc = AdxDatabaseService(kusto_client=kusto_client, state=state["services"])
-        name = f"{organization_id}-{work_key}"
+        name = f"{organization_id}-{workspace_key}"
         available = adx_svc.check(name=name)
         to_create = adx_section.get("database").get("create", True)
         if available and to_create:
@@ -238,12 +238,12 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
         adx_svc = ArmService(arm_client=arm_client, state=state.get("services"))
         to_create = eventhub_section.get("create", True)
         if to_create:
-            deployment_name = f"{organization_id}-evn-{work_key}"
+            deployment_name = f"{organization_id}-evn-{workspace_key}"
             adx_svc.run(deployment_name=deployment_name, file="eventhub_deploy.json")
         arm_svc = AzureIamService(iam_client=iam_client, state=state.get("services"))
         principal_id = state["services"]["adx"]["cluster_principal_id"]
         resource_type = "Microsoft.EventHub/Namespaces"
-        resource_name = f"{organization_id}-{work_key}"
+        resource_name = f"{organization_id}-{workspace_key}"
         role_id = state["services"]["azure"]["eventhub_built_data_receiver"]
         arm_svc.set(
             principal_id=principal_id,
@@ -253,7 +253,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
         )
         principal_id = state["services"]["platform"]["principal_id"]
         resource_type = "Microsoft.EventHub/Namespaces"
-        resource_name = f"{organization_id}-{work_key}"
+        resource_name = f"{organization_id}-{workspace_key}"
         role_id = state["services"]["azure"]["eventhub_built_data_sender"]
         arm_svc.set(
             principal_id=principal_id,
@@ -263,7 +263,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
         )
         principal_id = state["services"]["babylon"]["principal_id"]
         resource_type = "Microsoft.EventHub/Namespaces"
-        resource_name = f"{organization_id}-{work_key}"
+        resource_name = f"{organization_id}-{workspace_key}"
         role_id = state["services"]["azure"]["eventhub_built_data_sender"]
         arm_svc.set(
             principal_id=principal_id,

--- a/Babylon/commands/macro/deploy_workspace.py
+++ b/Babylon/commands/macro/deploy_workspace.py
@@ -42,7 +42,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
     _ret.append("Workspace deployment")
     _ret.append("")
     click.echo(click.style("\n".join(_ret), bold=True, fg="green"))
-    platform_url, workspace_key = env.get_ns_from_text(content=namespace)
+    platform_url, workspace_key = env.get_ns_from_text(content=namespace, file_content=file_content)
     state = env.retrieve_state_func(state_id=env.state_id)
     state["services"]["api"]["url"] = platform_url
     state["services"]["azure"]["tenant_id"] = env.tenant_id

--- a/Babylon/commands/macro/deploy_workspace.py
+++ b/Babylon/commands/macro/deploy_workspace.py
@@ -54,9 +54,7 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
     ext_args = dict(azure_function_secret=azf_secret)
     content = env.fill_template(data=file_content, state=state, ext_args=ext_args)
     payload: dict = content.get("spec").get("payload")
-    work_key = payload.get("key")
-    state["services"]["api"]["workspace_key"] = work_key
-    state["services"]["adx"]["database_name"] = f"{organization_id}-{work_key}"
+    state["services"]["adx"]["database_name"] = f"{organization_id}-{workspace_key}"
     spec = dict()
     spec["payload"] = json.dumps(payload, indent=2, ensure_ascii=True)
     azure_token = get_azure_token("csm_api")

--- a/Babylon/commands/macro/deploy_workspace.py
+++ b/Babylon/commands/macro/deploy_workspace.py
@@ -49,7 +49,6 @@ def deploy_workspace(namespace: str, file_content: str, deploy_dir: pathlib.Path
     state["services"]["api"]["workspace_key"] = workspace_key
     subscription_id = state["services"]["azure"]["subscription_id"]
     organization_id = state["services"]["api"]["organization_id"]
-    workspace_key = workspace_key or state["services"]["api"]["workspace_key"]
     azf_secret = env.get_project_secret(organization_id=organization_id, workspace_key=workspace_key, name="azf")
     ext_args = dict(azure_function_secret=azf_secret)
     content = env.fill_template(data=file_content, state=state, ext_args=ext_args)

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -412,21 +412,20 @@ class Environment(metaclass=SingletonMeta):
         self.set_org_name()
         self.set_blob_client()
         return platform_url
-    
-    def init_workspace_key_from_yaml (self, vars):
+
+    def init_workspace_key_from_yaml(self, vars):
         workspace_file = self.pwd / "project" / "workspace.yaml"
         if not workspace_file.exists():
             logger.error(f"{workspace_file} not found")
             sys.exit(1)
         workspace_content = workspace_file.open().read()
-        workspace_content_replace = workspace_content.replace("{{", "${").replace("}}", "}").replace("services", "")
+        workspace_content_replace = (workspace_content.replace("{{", "${").replace("}}", "}").replace("services", ""))
         t = Template(text=workspace_content_replace, strict_undefined=True)
         payload = t.render(**vars)
         payload_dict = yaml.safe_load(payload)
-        key =  payload_dict.get("spec").get("payload", {}).get("key")
-        if(key == "" or key is None):
+        key = payload_dict.get("spec").get("payload", {}).get("key")
+        if key == "" or key is None:
             logger.error("The key parameter in workspace payload is empty ")
             sys.exit(1)
 
         return key
-

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -419,8 +419,6 @@ class Environment(metaclass=SingletonMeta):
     def get_metadata(self, vars: dict, content: str):
         result = (content.replace("{{", "${").replace("}}", "}").replace("services", ""))
         t = Template(text=result, strict_undefined=True)
-        # print(vars)
-        # sys.exit(1)
         replace = t.render(**vars)
         content = yaml.safe_load(replace)
         metadata = content.get("metadata", {})

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -75,6 +75,8 @@ class Environment(metaclass=SingletonMeta):
         if variables_file.exists():
             logger.debug(f"Loading variables from {variables_file}")
             vars = yaml.safe_load(variables_file.open()) or dict()
+        vars["secret_powerbi"] = ""
+        vars["github_secret"] = ""
         return vars
 
     def get_ns_from_text(self, content: str, file_content: str):
@@ -417,6 +419,8 @@ class Environment(metaclass=SingletonMeta):
     def get_metadata(self, vars: dict, content: str):
         result = (content.replace("{{", "${").replace("}}", "}").replace("services", ""))
         t = Template(text=result, strict_undefined=True)
+        # print(vars)
+        # sys.exit(1)
         replace = t.render(**vars)
         content = yaml.safe_load(replace)
         metadata = content.get("metadata", {})

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -94,7 +94,7 @@ class Environment(metaclass=SingletonMeta):
             logger.error("platform id is mandatory")
             sys.exit(1)
         platform_url = plt_obj.get("url", "")
-        metadatas = self.get_metadata(vars, file_content)
+        metadata = self.get_metadata(vars, file_content)
         if not platform_url:
             logger.error("url is mandatory")
             sys.exit(1)
@@ -104,7 +104,7 @@ class Environment(metaclass=SingletonMeta):
         self.set_server_id()
         self.set_org_name()
         self.set_blob_client()
-        return platform_url, metadatas.get('workspace_key')
+        return platform_url, metadata.get('workspace_key') or ""
 
     def fill_template(self, data: str, state: dict = None, ext_args: dict = None):
         result = data.replace("{{", "${").replace("}}", "}")
@@ -419,5 +419,5 @@ class Environment(metaclass=SingletonMeta):
         t = Template(text=result, strict_undefined=True)
         replace = t.render(**vars)
         content = yaml.safe_load(replace)
-        metadatas = content.get("metadatas", {})
-        return metadatas
+        metadata = content.get("metadata", {})
+        return metadata

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -103,7 +103,7 @@ class Environment(metaclass=SingletonMeta):
         self.set_server_id()
         self.set_org_name()
         self.set_blob_client()
-        return platform_url, vars.get('workspace_key', "")
+        return platform_url, vars.get('workspace_key', self.init_workspace_key_from_yaml(vars))
 
     def fill_template(self, data: str, state: dict = None, ext_args: dict = None):
         result = data.replace("{{", "${").replace("}}", "}")
@@ -412,3 +412,21 @@ class Environment(metaclass=SingletonMeta):
         self.set_org_name()
         self.set_blob_client()
         return platform_url
+    
+    def init_workspace_key_from_yaml (self, vars):
+        workspace_file = self.pwd / "project" / "workspace.yaml"
+        if not workspace_file.exists():
+            logger.error(f"{workspace_file} not found")
+            sys.exit(1)
+        workspace_content = workspace_file.open().read()
+        workspace_content_replace = workspace_content.replace("{{", "${").replace("}}", "}").replace("services", "")
+        t = Template(text=workspace_content_replace, strict_undefined=True)
+        payload = t.render(**vars)
+        payload_dict = yaml.safe_load(payload)
+        key =  payload_dict.get("spec").get("payload", {}).get("key")
+        if(key == "" or key is None):
+            logger.error("The key parameter in workspace payload is empty ")
+            sys.exit(1)
+
+        return key
+

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -77,7 +77,7 @@ class Environment(metaclass=SingletonMeta):
             vars = yaml.safe_load(variables_file.open()) or dict()
         return vars
 
-    def get_ns_from_text(self, content: str):
+    def get_ns_from_text(self, content: str, file_content: str):
         result = content.replace("services", "")
         t = Template(text=result, strict_undefined=True)
         vars = self.get_variables()
@@ -94,6 +94,7 @@ class Environment(metaclass=SingletonMeta):
             logger.error("platform id is mandatory")
             sys.exit(1)
         platform_url = plt_obj.get("url", "")
+        metadatas = self.get_metadata(vars, file_content)
         if not platform_url:
             logger.error("url is mandatory")
             sys.exit(1)
@@ -103,7 +104,7 @@ class Environment(metaclass=SingletonMeta):
         self.set_server_id()
         self.set_org_name()
         self.set_blob_client()
-        return platform_url, vars.get('workspace_key', self.init_workspace_key_from_yaml(vars))
+        return platform_url, metadatas.get('workspace_key')
 
     def fill_template(self, data: str, state: dict = None, ext_args: dict = None):
         result = data.replace("{{", "${").replace("}}", "}")
@@ -413,19 +414,10 @@ class Environment(metaclass=SingletonMeta):
         self.set_blob_client()
         return platform_url
 
-    def init_workspace_key_from_yaml(self, vars):
-        workspace_file = self.pwd / "project" / "workspace.yaml"
-        if not workspace_file.exists():
-            logger.error(f"{workspace_file} not found")
-            sys.exit(1)
-        workspace_content = workspace_file.open().read()
-        workspace_content_replace = (workspace_content.replace("{{", "${").replace("}}", "}").replace("services", ""))
-        t = Template(text=workspace_content_replace, strict_undefined=True)
-        payload = t.render(**vars)
-        payload_dict = yaml.safe_load(payload)
-        key = payload_dict.get("spec").get("payload", {}).get("key")
-        if key == "" or key is None:
-            logger.error("The key parameter in workspace payload is empty ")
-            sys.exit(1)
-
-        return key
+    def get_metadata(self, vars: dict, content: str):
+        result = (content.replace("{{", "${").replace("}}", "}").replace("services", ""))
+        t = Template(text=result, strict_undefined=True)
+        replace = t.render(**vars)
+        content = yaml.safe_load(replace)
+        metadatas = content.get("metadatas", {})
+        return metadatas

--- a/Babylon/version.py
+++ b/Babylon/version.py
@@ -1,4 +1,4 @@
-VERSION = '4.0.20'
+VERSION = '4.1.0'
 
 
 def get_version():


### PR DESCRIPTION
For the ticket SDCOSMO-1950, I add a key parameter in the webapp payload then, I use it to initialize correctly the workspace_key in the babylon project. Finally, this workspace_key will be used to create AZ function.