### PR TITLE
chore: provide version information for scanner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+# SonarQube configuration for CosmoTech projects
+# ----------------------------------------------
+
+# Documentation:
+# -------------
+# for the SonarQube server: https://docs.sonarsource.com/sonarqube-server/2025.1/analyzing-source-code/scanners/sonarscanner/
+# for the scanners workflow : https://github.com/Cosmo-Tech/sonarqube-scanner
+
+
+# Language-specific configurations
+# ------------------------------
+# Python version(s) used in the project
+sonar.python.version=3.9,3.10,3.11,3.12
+
+# To ignore specific files or directories:
+#sonar.exclusions=**/tests/**,**/vendor/**


### PR DESCRIPTION
SonarQube scanner will give more informative
results if we provide some information that
it cannot detect automatically, such as the
Python version.