### PR TITLE
ci: provide version information for scanner

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,38 @@
+# CosmoTech template for SonarQube configuration v0.7.0
+# -----------------------------------------------------
+
+# This file is used to configure the SonarQube scanner for a project. Rename it
+# to sonar-project.properties and copy to the root of your project directory.
+# https://github.com/Cosmo-Tech/sonarqube-scanner/blob/main/docs/sonar-project.properties.template
+
+
+# Default project identification properties
+# -----------------------------------------
+# These properties are hardcoded in the sonarqube-scanner as they are shared
+# across all CosmoTech projects. Uncomment them only if you want to override
+# and you know what you are doing.
+
+# sonar.projectKey=your-project-key      # Unique identifier for your project
+# sonar.projectName=Your Project Name    # Display name for your project
+# sonar.projectVersion=1.0.0             # Version of your project
+
+# Source code and testing configuration
+# -----------------------------------
+# A file should either be in source or test directory, not both. By default 
+# everything is source
+# Define source directories to analyze:
+# sonar.sources=sonarqube_scanner
+# Define test directories:
+# sonar.tests=tests
+
+# Completely ignore files with the following patterns:
+# sonar.exclusions=do_not_look_inside/**
+
+# Code duplication detection settings 
+# sonar.cpd.exclusions=embarassing_code/**,copy_pasted_scripts/**
+
+# Language-specific configurations
+# ------------------------------
+# Python version(s) used in the project (comma-separated list of supported versions)
+sonar.python.version=3.10,3.11,3.12,3.13
+


### PR DESCRIPTION
SonarQube scanner will give more informative
results if we provide some information that
it cannot detect automatically, such as the
Python version. Use scanner properties from
template