### PR TITLE
fix: ensure correct version for azure-mgmt-core in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Azure connection requirements
 azure-identity
+azure-mgmt-core==1.4.0
 azure-mgmt-subscription
 azure-mgmt-kusto
 azure-kusto-data


### PR DESCRIPTION
Fixed babylon installation issue : 

```bash
python3 -m venv .venv
# Active Python environnement
source .venv/bin/activate
# Install Babylon and his dependencies
pip install git+https://github.com/Cosmo-Tech/Babylon.git@4.2.3
babylon
```

=> Will fail

```bash
ImportError: cannot import name 'Deployment' from 'azure.mgmt.resource.resources.models' (/home/jfolly/sd44/.venv/lib/python3.13/site-packages/azure/mgmt/resource/resources/models/__init__.py)
```
