### PR TITLE
Remove 'sdkVersion' from solution input

### DIFF
--- a/Babylon/templates/working_dir/.templates/yaml/Solution.yaml
+++ b/Babylon/templates/working_dir/.templates/yaml/Solution.yaml
@@ -12,7 +12,6 @@ spec:
     description: "{{solution_description}}"
     repository: "{{simulator_repository}}"
     version: "{{simulator_version}}"
-    sdkVersion: "{{sdkVersion}}"
     alwaysPull: true
     url: 'https://{{cluster_name}}.{{domain_zone}}/tenant-{{tenant}}/webapp-{{webapp_name}}'
     tags:

--- a/Babylon/templates/working_dir/.templates/yaml/azure/variables.yaml
+++ b/Babylon/templates/working_dir/.templates/yaml/azure/variables.yaml
@@ -10,7 +10,6 @@ simulator_repository: tenant-sphinx/brewerysamplesolution_simulator
 solution_description: Brewery Testing babylon v5 Solution PLT
 solution_key: breweryTesting
 simulator_version: 3.0.2
-sdkVersion: 12.2.0
 # Workspace
 workspace_name: Babylon v5 workspace
 workspace_key: brewerytestingwork
@@ -40,16 +39,16 @@ tf_webapp_version: 1.0.3
 # Remote state
 remote: true
 
-# documentation url 
+# documentation url
 documentation_url: 'https://portal.cosmotech.com/resources/platform-resources/web-app-user-guide'
 
 # ACL
 security:
   default: none
   accessControlList:
-    - id: tenant-admin 
+    - id: tenant-admin
       role: admin
     - id: tenant-editor
       role: editor
-    - id: tenant-viewer 
+    - id: tenant-viewer
       role: viewer

--- a/Babylon/templates/working_dir/.templates/yaml/kob/variables.yaml
+++ b/Babylon/templates/working_dir/.templates/yaml/kob/variables.yaml
@@ -10,7 +10,6 @@ simulator_repository: tenant-sphinx/brewerysamplesolution_simulator
 solution_description: Brewery Testing babylon v5 Solution PLT
 solution_key: breweryTesting
 simulator_version: 3.0.2
-sdkVersion: 12.2.0
 # Workspace
 workspace_name: Babylon v5 workspace
 workspace_key: brewerytestingwork
@@ -39,16 +38,16 @@ tf_webapp_version: 1.0.3
 # Remote state
 remote: true
 
-# documentation url 
+# documentation url
 documentation_url: 'https://portal.cosmotech.com/resources/platform-resources/web-app-user-guide'
 
 # ACL
 security:
   default: none
   accessControlList:
-    - id: tenant-admin 
+    - id: tenant-admin
       role: admin
     - id: tenant-editor
       role: editor
-    - id: tenant-viewer 
+    - id: tenant-viewer
       role: viewer


### PR DESCRIPTION
This field is not modifiable anymore in the run api 5.0.0+ It is provided read-only and computed based on metadata from the simulator docker image