### PR TITLE
Add a --kube-context option to support explicit k8s context

### DIFF
--- a/Babylon/commands/macro/helpers/workspace/kubernetes_helper.py
+++ b/Babylon/commands/macro/helpers/workspace/kubernetes_helper.py
@@ -29,8 +29,7 @@ from pathlib import Path
 from string import Template
 from textwrap import dedent
 
-from kubernetes import client, config, utils
-from kubernetes import config as kube_config
+from kubernetes import client, utils
 from kubernetes.utils import FailToCreateError
 from yaml import safe_load
 
@@ -114,9 +113,8 @@ def get_postgres_service_host(namespace: str) -> str:
     cluster. External database clusters are not currently supported.
     """
     try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        services = v1.list_namespaced_service(namespace)
+        k8s_client = env.get_kubernetes_client()
+        services = k8s_client.list_namespaced_service(namespace)
 
         for svc in services.items:
             labels = svc.metadata.labels or {}
@@ -164,9 +162,8 @@ def create_workspace_secret(
     )
 
     try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        v1.create_namespaced_secret(namespace=namespace, body=secret)
+        k8s_client = env.get_kubernetes_client()
+        k8s_client.create_namespaced_secret(namespace=namespace, body=secret)
         logger.info(f"  [bold green]✔[/bold green] Secret [magenta]{secret_name}[/magenta] created")
         return True
     except client.exceptions.ApiException as e:
@@ -225,9 +222,8 @@ def create_coal_configmap(
     )
 
     try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
-        v1.create_namespaced_config_map(namespace=namespace, body=configmap)
+        k8s_client = env.get_kubernetes_client()
+        k8s_client.create_namespaced_config_map(namespace=namespace, body=configmap)
         logger.info(f"  [bold green]✔[/bold green] ConfigMap [magenta]{configmap_name}[/magenta] created")
         return True
     except client.ApiException as e:
@@ -259,8 +255,7 @@ def _run_schema_init_job(
 ) -> None:
     """Apply a single K8s init job from *script_path* and wait for its outcome."""
     k8s_job_name = f"postgresql-init-{workspace_id}"
-    kube_config.load_kube_config()
-    k8s_client = client.ApiClient()
+    k8s_client = env.get_kubernetes_client()
 
     with open(script_path, "r") as f:
         raw_content = f.read()
@@ -373,8 +368,7 @@ def destroy_postgres_schema(schema_name: str, state: dict) -> None:
     }
     destroy_jobs = env.original_template_path / "yaml" / "k8s_job_destroy.yaml"
     k8s_job_name = f"postgresql-destroy-{workspace_id_tmp}"
-    kube_config.load_kube_config()
-    k8s_client = client.ApiClient()
+    k8s_client = env.get_kubernetes_client()
 
     with open(destroy_jobs, "r") as f:
         raw_content = f.read()
@@ -464,22 +458,21 @@ def delete_kubernetes_resources(namespace: str, organization_id: str, workspace_
     configmap_name = f"{organization_id}-{workspace_id}-coal-config"
 
     try:
-        config.load_kube_config()
-        v1 = client.CoreV1Api()
+        k8s_client = env.get_kubernetes_client()
     except Exception as e:
         logger.error("  [bold red]✘[/bold red] Failed to initialise Kubernetes client")
         logger.debug(f"  Detail: {e}", exc_info=True)
         return
 
-    _delete_secret(v1, secret_name, namespace)
-    _delete_configmap(v1, configmap_name, namespace)
+    _delete_secret(k8s_client, secret_name, namespace)
+    _delete_configmap(k8s_client, configmap_name, namespace)
 
 
-def _delete_secret(v1: client.CoreV1Api, secret_name: str, namespace: str) -> None:
+def _delete_secret(k8s_client: client.CoreV1Api, secret_name: str, namespace: str) -> None:
     """Delete a single named Secret, ignoring 404."""
     try:
         logger.info("  [dim]→ Deleting workspace Secret ...[/dim]")
-        v1.delete_namespaced_secret(name=secret_name, namespace=namespace)
+        k8s_client.delete_namespaced_secret(name=secret_name, namespace=namespace)
         logger.info(f"  [bold green]✔[/bold green] Secret [magenta]{secret_name}[/magenta] deleted")
     except client.ApiException as e:
         if e.status == 404:
@@ -491,11 +484,11 @@ def _delete_secret(v1: client.CoreV1Api, secret_name: str, namespace: str) -> No
         logger.debug(f"  Detail: {e}", exc_info=True)
 
 
-def _delete_configmap(v1: client.CoreV1Api, configmap_name: str, namespace: str) -> None:
+def _delete_configmap(k8s_client: client.CoreV1Api, configmap_name: str, namespace: str) -> None:
     """Delete a single named ConfigMap, ignoring 404."""
     try:
         logger.info("  [dim]→ Deleting workspace ConfigMap ...[/dim]")
-        v1.delete_namespaced_config_map(name=configmap_name, namespace=namespace)
+        k8s_client.delete_namespaced_config_map(name=configmap_name, namespace=namespace)
         logger.info(f"  [bold green]✔[/bold green] ConfigMap [magenta]{configmap_name}[/magenta] deleted")
     except client.ApiException as e:
         if e.status == 404:

--- a/Babylon/main.py
+++ b/Babylon/main.py
@@ -78,6 +78,10 @@ def setup_logging(log_path: pathlibPath = pathlibPath.cwd()) -> None:
     )
 
 
+def setup_kube_context(ctx, param, kube_context):
+    env.set_kube_context(kube_context)
+
+
 @group(name="babylon", invoke_without_command=False)
 @click_log.simple_verbosity_option(logger)
 @option(
@@ -104,6 +108,14 @@ def setup_logging(log_path: pathlibPath = pathlibPath.cwd()) -> None:
     type=clickPath(file_okay=False, dir_okay=True, writable=True, path_type=pathlibPath),
     default=pathlibPath.cwd(),
     help="Path to the directory where log files will be stored. If not set, defaults to current working directory.",
+)
+@option(
+    "--kube-context",
+    type=str,
+    default=None,
+    callback=setup_kube_context,
+    expose_value=False,
+    help="Name of the kubeconfig context to use instead of the current context for relevant commands",
 )
 @option(
     INTERACTIVE_ARG_VALUE,

--- a/Babylon/utils/environment.py
+++ b/Babylon/utils/environment.py
@@ -54,6 +54,7 @@ class Environment(metaclass=SingletonMeta):
         self.remote = False
         self.pwd = Path.cwd()
         self.blob_client = None
+        self._kube_context = None
         self.context_id: str = ""
         self.environ_id: str = ""
         self.server_id: str = ""
@@ -107,13 +108,33 @@ class Environment(metaclass=SingletonMeta):
         payload_dict = loads(payload_json)
         return payload_dict
 
+    def set_kube_context(self, kube_context):
+        self._kube_context = kube_context
+
     def set_context(self, context_id):
         self.context_id = context_id
 
     def set_environ(self, environ_id):
         self.environ_id = environ_id
 
+    def get_kubernetes_client(self) -> client.CoreV1Api:
+        try:
+            config.load_kube_config(context=self._kube_context)
+            return client.CoreV1Api()
+        except ConfigException as exc:
+            logger.error("\n  [bold red]✘[/bold red] Failed to load kube config")
+            logger.error(f"  [red]Reason:[/red] {exc}")
+            logger.info("\n [bold white]💡 Troubleshooting:[/bold white]")
+            logger.info("  • Ensure your kubeconfig file is valid")
+            logger.info("  • Ensure the kubernetes context is correct:")
+            logger.info("    - Either set it as current: [cyan]kubectl config use-context <context-name>[/cyan]")
+            logger.info("    - Or explicitly specify it: [cyan]babylon --kube-context <context-name> ...[/cyan]")
+            sys.exit(1)
+
     def _get_active_kubectl_context(self) -> str:
+        if self._kube_context:
+            return self._kube_context
+
         try:
             from kubernetes.config.kube_config import list_kube_config_contexts
 
@@ -136,8 +157,8 @@ class Environment(metaclass=SingletonMeta):
 
     def _load_k8s_secret(self, secret_name: str, tenant: str):
         try:
-            v1 = client.CoreV1Api()
-            return v1.read_namespaced_secret(name=secret_name, namespace=tenant)
+            k8s_client = self.get_kubernetes_client()
+            return k8s_client.read_namespaced_secret(name=secret_name, namespace=tenant)
         except ApiException:
             logger.error(
                 f"  [yellow]⚠[/yellow] Secret [green]{secret_name}[/green] could not be found in namespace [green]{tenant}[/green]."
@@ -145,8 +166,9 @@ class Environment(metaclass=SingletonMeta):
             logger.info("\n [bold white]💡 Troubleshooting:[/bold white]")
             logger.info(f"  • Active kubectl context : [cyan]{self._get_active_kubectl_context()}[/cyan]")
             logger.info(f"  • Active Babylon namespace: {self._get_babylon_namespace_info()}")
-            logger.info("  • If the kubectl context is wrong, switch it:")
-            logger.info("    [cyan]kubectl config use-context <context-name>[/cyan]")
+            logger.info("  • If the kubectl context is wrong:")
+            logger.info("    - Either switch it: [cyan]kubectl config use-context <context-name>[/cyan]")
+            logger.info("    - Or explicitly specify it: [cyan]babylon --kube-context <context-name> ...[/cyan]")
             logger.info("  • If the Babylon namespace is wrong, switch it:")
             logger.info("    [cyan]babylon namespace use -c <context> -t <tenant>[/cyan]")
             sys.exit(1)
@@ -158,16 +180,6 @@ class Environment(metaclass=SingletonMeta):
             sys.exit(1)
 
     def get_config_from_k8s_secret_by_tenant(self, secret_name: str, tenant: str):
-        try:
-            config.load_kube_config()
-        except ConfigException as e:
-            logger.error("\n  [bold red]✘[/bold red] Failed to load kube config")
-            logger.error(f"  [red]Reason:[/red] {e}")
-            logger.info("\n [bold white]💡 Troubleshooting:[/bold white]")
-            logger.info("  • Ensure your kubeconfig file is valid")
-            logger.info("  • Set your context: [cyan]kubectl config use-context <context-name>[/cyan]")
-            sys.exit(1)
-
         secret = self._load_k8s_secret(secret_name, tenant)
 
         if not secret.data:
@@ -186,7 +198,7 @@ class Environment(metaclass=SingletonMeta):
         """Persist *state* as a Kubernetes Secret."""
         ns = namespace or self.environ_id
         name = secret_name or f"babylon-state-{self.context_id}-{self.environ_id}"
-        save_state_in_kubernetes(namespace=ns, secret_name=name, state_data=state)
+        save_state_in_kubernetes(self.get_kubernetes_client(), namespace=ns, secret_name=name, state_data=state)
 
     def get_state_from_kubernetes(self, namespace: str = "", secret_name: str = "") -> dict:
         """Retrieve state from a Kubernetes Secret.
@@ -197,7 +209,7 @@ class Environment(metaclass=SingletonMeta):
         """
         ns = namespace or self.environ_id
         name = secret_name or f"babylon-state-{self.context_id}-{self.environ_id}"
-        result = retrieve_state_from_kubernetes(namespace=ns, secret_name=name)
+        result = retrieve_state_from_kubernetes(self.get_kubernetes_client(), namespace=ns, secret_name=name)
         if result is None:
             return {
                 "context": self.context_id,
@@ -227,9 +239,8 @@ class Environment(metaclass=SingletonMeta):
         over the wire — no client-side filtering needed.
         """
         try:
-            config.load_kube_config()
-            v1 = client.CoreV1Api()
-            secrets = v1.list_namespaced_secret(
+            k8s_client = self.get_kubernetes_client()
+            secrets = k8s_client.list_namespaced_secret(
                 namespace=self.environ_id,
                 label_selector=f"{STATE_LABEL_KEY}={STATE_LABEL_VALUE}",
             )

--- a/Babylon/utils/kubernetes_state.py
+++ b/Babylon/utils/kubernetes_state.py
@@ -22,9 +22,8 @@ import sys
 from base64 import b64decode, b64encode
 from logging import getLogger
 
-from kubernetes import client, config
+from kubernetes import client
 from kubernetes.client.exceptions import ApiException
-from kubernetes.config.config_exception import ConfigException
 from yaml import dump, safe_load
 
 logger = getLogger(__name__)
@@ -39,24 +38,6 @@ STATE_LABEL_VALUE = "babylon-state"
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
-
-
-def _load_kube_config() -> None:
-    """Load kubeconfig, with a clear error message on failure."""
-    try:
-        config.load_kube_config()
-    except ConfigException as exc:
-        logger.error("\n  [bold red]✘[/bold red] Failed to load kube config")
-        logger.error(f"  [red]Reason:[/red] {exc}")
-        logger.info("\n [bold white]💡 Troubleshooting:[/bold white]")
-        logger.info("  • Ensure your kubeconfig file is valid")
-        logger.info("  • Set your context: [cyan]kubectl config use-context <context-name>[/cyan]")
-        sys.exit(1)
-
-
-def _core_v1() -> client.CoreV1Api:
-    """Return a CoreV1Api instance (kubeconfig must already be loaded)."""
-    return client.CoreV1Api()
 
 
 def _encode(data: dict) -> str:
@@ -93,23 +74,21 @@ def _build_secret(namespace: str, secret_name: str, encoded_value: str) -> clien
 # Public API
 
 
-def save_state_in_kubernetes(namespace: str, secret_name: str, state_data: dict) -> None:
+def save_state_in_kubernetes(k8s_client: client.CoreV1Api, namespace: str, secret_name: str, state_data: dict) -> None:
     """Persist *state_data* as a Kubernetes Secret in *namespace*."""
-    _load_kube_config()
-    v1 = _core_v1()
     encoded = _encode(state_data)
     secret = _build_secret(namespace, secret_name, encoded)
 
     try:
-        existing_secret = v1.read_namespaced_secret(name=secret_name, namespace=namespace)
+        existing_secret = k8s_client.read_namespaced_secret(name=secret_name, namespace=namespace)
         if existing_secret.metadata and secret.metadata:
             secret.metadata.resource_version = existing_secret.metadata.resource_version
-            v1.replace_namespaced_secret(name=secret_name, namespace=namespace, body=secret)
+            k8s_client.replace_namespaced_secret(name=secret_name, namespace=namespace, body=secret)
             logger.info(f"  [green]✔[/green] State secret [cyan]{secret_name}[/cyan] updated in namespace [cyan]{namespace}[/cyan]")
     except ApiException as exc:
         if exc.status == 404:
             # Secret does not exist → create it.
-            v1.create_namespaced_secret(namespace=namespace, body=secret)
+            k8s_client.create_namespaced_secret(namespace=namespace, body=secret)
             logger.info(f"  [green]✔[/green] State secret [cyan]{secret_name}[/cyan] created in namespace [cyan]{namespace}[/cyan]")
         else:
             logger.error(f"  [bold red]✘[/bold red] Kubernetes API error while storing state (HTTP {exc.status}): {exc.reason}")
@@ -119,17 +98,15 @@ def save_state_in_kubernetes(namespace: str, secret_name: str, state_data: dict)
         sys.exit(1)
 
 
-def retrieve_state_from_kubernetes(namespace: str, secret_name: str) -> dict | None:
+def retrieve_state_from_kubernetes(k8s_client: client.CoreV1Api, namespace: str, secret_name: str) -> dict | None:
     """Read state from a Kubernetes Secret and return it as a dictionary.
 
     Returns ``None`` when the secret does not exist so the caller can decide
     whether to initialise a fresh state or raise an error.
     """
-    _load_kube_config()
-    v1 = _core_v1()
 
     try:
-        secret = v1.read_namespaced_secret(name=secret_name, namespace=namespace)
+        secret = k8s_client.read_namespaced_secret(name=secret_name, namespace=namespace)
     except ApiException as exc:
         if exc.status == 404:
             logger.warning(


### PR DESCRIPTION
This allows to explicitly set the kubernetes context to use instead of relying on the currently set context and/or having to switch the current context. I've followed the option naming from `helm`.

Another usage pattern is to separate the cluster/context into separate kubeconfig files. If you think this would be a good idea to also support that I can add it rather easily.